### PR TITLE
Fix docs for 6.3 by fixing rename-defines macro.

### DIFF
--- a/math-doc/math/scribblings/rename-defines.rkt
+++ b/math-doc/math/scribblings/rename-defines.rkt
@@ -14,6 +14,7 @@
           (with-syntax ([(y ...)  (generate-temporaries #'(x ...))])
             (syntax/loc stx
               (begin
+                (define-syntaxes (y ...) (values))
                 (define-syntax x (make-rename-transformer #'y)) ...
                 (define-values (y ...) expr))))]
          [(begin e ...)


### PR DESCRIPTION
Fix suggested by @takikawa.