### PR TITLE
don't require for/flvector forms from racket/flonum

### DIFF
--- a/math-lib/math/private/flonum/flvector-syntax.rkt
+++ b/math-lib/math/private/flonum/flvector-syntax.rkt
@@ -12,7 +12,7 @@
                        typed/untyped-utils)
            typed/racket/base
            racket/unsafe/ops
-           racket/flonum
+           (except-in racket/flonum for/flvector for*/flvector)
            racket/fixnum
            "../syntax-utils.rkt"
            "../exception.rkt"
@@ -103,7 +103,7 @@
   )  ; module
 
 (module defs typed/racket/base
-  (require racket/flonum
+  (require (except-in racket/flonum for/flvector for*/flvector)
            racket/fixnum
            racket/unsafe/ops
            (submod ".." syntax-defs)

--- a/math-lib/math/private/syntax-utils.rkt
+++ b/math-lib/math/private/syntax-utils.rkt
@@ -15,7 +15,7 @@
       [_  (syntax/loc stx typed-op)])))
 
 (module ensures racket/base
-  (require racket/flonum
+  (require (except-in racket/flonum for/flvector for*/flvector)
            typed/racket/base)
   
   (provide (all-defined-out))


### PR DESCRIPTION
This would give room to allow typed racket to provide typed versions of `for/flvector` and `for*/flvector` (see https://github.com/racket/typed-racket/pull/534).