### PR TITLE
Poisson pdf limits1

### DIFF
--- a/math-lib/math/private/distributions/impl/poisson-pdf.rkt
+++ b/math-lib/math/private/distributions/impl/poisson-pdf.rkt
@@ -116,10 +116,8 @@
          ;; Error <= 1 ulp when flpoisson-pdf error is just a few ulps
          (define answ (fllog (flpoisson-pdf l k)))
          (cond
-           [(fl< answ -700.0)
-            (define bns (flpoisson-log-pdf-logassymp l k))
-            ;bail out -> rounding errors to big in this region
-            bns]
+           ;bail out -> rounding errors to big in this region
+           [(fl< answ -700.0) (flpoisson-log-pdf-logassymp l k)]
            [else answ])]
         [(and (or (l . fl> . 1e18) (k . fl> . 1e18))
               (or ((fl- k l) . fl> . (fl* 0.5 k))

--- a/math-lib/math/private/distributions/impl/poisson-pdf.rkt
+++ b/math-lib/math/private/distributions/impl/poisson-pdf.rkt
@@ -112,7 +112,7 @@
          (- (fl* k (fllog l)) (fllog k) (fllog-gamma k) l)]
         [(and (k . fl> . 2.0) (l . fl> . 2.0)
               ((fl- k l) . fl< . (fl* 40.0 (flsqrt l)))
-              ((fl- l k) . fl< . (fl* 29.0 (flsqrt l))))
+              ((fl- l k) . fl< . (fl* 38.0 (flsqrt l))))
          ;; Error <= 1 ulp when flpoisson-pdf error is just a few ulps
          (define answ (fllog (flpoisson-pdf l k)))
          (cond


### PR DESCRIPTION
this adresses [Issue 2](https://github.com/racket/math/issues/2).
I tried solving it by changing the boundaries for the problematic case (see [ 68e0f85](https://github.com/bdeket/math/commit/68e0f856ee0aa27e749256c0f5bafcc53347c472) ) but this is on average slower than just recalculating.
Note that the same problem also occurs for L~22000 near the upper boundary for this case.
Code used for investigating this can be found at: [http://pasterack.org/pastes/29444](http://pasterack.org/pastes/29444)

Result of the change (plotting error)
old:
![800-old](https://user-images.githubusercontent.com/6235541/61687501-d9700000-ad22-11e9-87fd-6462d59caab4.png)
new:
![800-new](https://user-images.githubusercontent.com/6235541/61687518-df65e100-ad22-11e9-947c-dc81702f515d.png)
old:
![22500-old](https://user-images.githubusercontent.com/6235541/61688285-e5f55800-ad24-11e9-89d3-f0ffee7d8d9e.png)
new:
![22500-new](https://user-images.githubusercontent.com/6235541/61688272-dfff7700-ad24-11e9-8732-d1a4999e7dd5.png)

legend: (see also pasterack code submodule test2)
 * blue/red dots: error > 1e-10
 * black line (old) boundary for the log calculation
 * x-axis= l-values
 * y-axis= k-values

error checked with bigfloat implementation
