### PR TITLE
Change solver for quadratic equations

### DIFF
--- a/math-doc/math/scribblings/math-number-theory.scrbl
+++ b/math-doc/math/scribblings/math-number-theory.scrbl
@@ -793,15 +793,8 @@ lowest term is the number @math-style{(p+r)/(q+s)}.
 @; ----------------------------------------
 @section[#:tag "quadratics"]{The Quadratic Equation}
 
-@defproc[(quadratic-complex-solutions [a Complex] [b Complex] [c Complex]) (Listof Complex)]{
-Returns a list of all complex solutions to the equation @math-style{a x^2 + b x +c = 0}.
-  @interaction[#:eval untyped-eval
-                      (quadratic-solutions 1 0 -1)
-                      (quadratic-solutions 1 2 1)
-                      (quadratic-solutions 1 0 1)]
-}
 
-@defproc[(quadratic-solutions [a Complex] [b Complex] [c Complex]) (Listof Real)]{
+@defproc[(quadratic-solutions [a Real] [b Real] [c Real]) (Listof Real)]{
 Returns a list of all real solutions to the equation @math-style{a x^2 + b x +c = 0}.
   @interaction[#:eval untyped-eval
                       (quadratic-solutions 1 0 -1)
@@ -809,20 +802,28 @@ Returns a list of all real solutions to the equation @math-style{a x^2 + b x +c 
                       (quadratic-solutions 1 0 1)]  
 }
 
-@defproc[(quadratic-integer-solutions [a Complex] [b Complex] [c Complex]) (Listof Integer)]{
+@defproc[(quadratic-integer-solutions [a Real] [b Real] [c Real]) (Listof Integer)]{
 Returns a list of all integer solutions to the equation @math-style{a x^2 + b x +c = 0}.
   @interaction[#:eval untyped-eval
                       (quadratic-integer-solutions 1 0 -1)
                       (quadratic-integer-solutions 1 0 -2)]  
 }
 
-@defproc[(quadratic-natural-solutions [a Complex] [b Complex] [c Complex]) (Listof Natural)]{
+@defproc[(quadratic-natural-solutions [a Real] [b Real] [c Real]) (Listof Natural)]{
 Returns a list of all natural solutions to the equation @math-style{a x^2 + b x +c = 0}.
   @interaction[#:eval untyped-eval
                       (quadratic-natural-solutions 1 0 -1)
                       (quadratic-natural-solutions 1 0 -2)]  
 }
 
+@defproc[(complex-quadratic-solutions [a Complex] [b Complex] [c Complex]) (Listof Complex)]{
+Returns a list of all complex solutions to the equation @math-style{a x^2 + b x +c = 0}.
+This function allows complex coeffecients.
+  @interaction[#:eval untyped-eval
+                      (complex-quadratic-solutions 1 0 1)
+                      (complex-quadratic-solutions 1 0 (sqrt -1))
+                      (complex-quadratic-solutions 1 0 1)]
+}
 
 
 @; ----------------------------------------

--- a/math-lib/math/private/number-theory/quadratic.rkt
+++ b/math-lib/math/private/number-theory/quadratic.rkt
@@ -4,32 +4,61 @@
          (only-in racket/math conjugate)
          "types.rkt")
 
-(provide quadratic-complex-solutions
-         quadratic-solutions
-         quadratic-integer-solutions
-         quadratic-natural-solutions)
+(provide complex-quadratic-solutions  ; complex coefficients
+         quadratic-solutions          ; real coefficients
+         quadratic-integer-solutions  ; coefficients
+         quadratic-natural-solutions) ;coefficients
 
-(: quadratic-complex-solutions  : Complex Complex Complex -> (Listof Complex))
-(define (quadratic-complex-solutions a b c)
+
+(: complex-quadratic-solutions  : Complex Complex Complex -> (Listof Complex))
+(define (complex-quadratic-solutions a b c)
+  ; Return list of solutions to a a x^2 + b x + c = 0
+  ; where a,b and c are complex numbers.
+  (let* ([d         (- (* b b) (* 4 a c))]
+         [sqrt-d    (sqrt d)]
+         [-b-sqrt-d (- (- b) sqrt-d)]
+         [2a        (* 2 a)])
+    (cond
+      [(= d 0) (list (/ b (- 2a)))]
+      [(= c 0) (list (/ (- (- b) sqrt-d) 2a)
+                     (/ (+ (- b) sqrt-d) 2a))]
+      ; use the standard formula, unless -b and sqrt are almost equal
+      [#t ; (> (magnitude -b-sqrt-d) 0.001)
+       (displayln d)
+       (list (/ -b-sqrt-d        2a)
+             (/ (+ (- b) sqrt-d) 2a))]
+      [else
+       ; Note: Disabled foe now.
+       ;       There are cases where only one root needs to
+       ;       use Muller's formula. But which one is it?
+       ; Muller's formula:
+       ;   x = 2c / ( -b +- sqrt(d) )
+       (let* ([sign (if (>= 0 (real-part (* (conjugate b) sqrt-d)))
+                        1 -1)]
+              [q    (/ (+ b (* sign sqrt-d)) -2)])
+         (append (list (/ q a) (/ c q))
+                 (list (/ (- (- b) sqrt-d) 2a)
+                       (/ (+ (- b) sqrt-d) 2a))))])))
+
+
+(: quadratic-solutions : Real Real Real -> (Listof Real))
+(define (quadratic-solutions a b c)
   ; return list of solutions to a a x^2 + b x + c = 0
   (let ([d (- (* b b) (* 4 a c))])
-    (if (= d 0)
-        (make-list 2 (/ b (* -2 a)))
-        (let* ([sqrt-d (sqrt d)]
-               [sign (if (>= 0 (real-part (* (conjugate b) sqrt-d))) 1 -1)]
-               [q (/ (+ b (* sign sqrt-d)) -2)])
-          (list (/ q a) (/ c q))))))
+    (cond
+      [(< d 0) '()]
+      [(= d 0) (list (/ b (* -2 a)))]
+      [else
+       (let ([sqrt-d (sqrt d)])
+         (list (/ (- (- b) sqrt-d) (* 2 a))
+               (/ (+ (- b) sqrt-d) (* 2 a))))])))
 
-(: quadratic-solutions : Complex Complex Complex -> (Listof Real))
-(define (quadratic-solutions a b c)
-  (filter real? (quadratic-solutions a b c)))
-
-(: quadratic-integer-solutions : Complex Complex Complex -> (Listof Integer))
+(: quadratic-integer-solutions : Real Real Real -> (Listof Integer))
 (define (quadratic-integer-solutions a b c)
   ; return list of integer solutions to a x^2 + b x + c = 0
   (filter exact-integer? (quadratic-solutions a b c)))
 
-(: quadratic-natural-solutions : Complex Complex Complex -> (Listof Natural))
+(: quadratic-natural-solutions : Real Real Real -> (Listof Natural))
 (define (quadratic-natural-solutions a b c)
   ; return list of nonnegative-integer solutions to a x^2 + b x + c = 0
   (filter natural? (quadratic-solutions a b c)))


### PR DESCRIPTION
Let the existing solvers take real coefficients.
The new solver complex-quadratic-solve allows complex coefficients.
Uncomment Muller's formula for now - it should only be applied,
when the standard formula is numerically unstable.
