### PR TITLE
Reimplemented quadratic-solutions in quadratic.rkt 

### DIFF
--- a/math-lib/math/private/number-theory/quadratic.rkt
+++ b/math-lib/math/private/number-theory/quadratic.rkt
@@ -47,10 +47,10 @@
       [else
        (let ([sqrt-d (sqrt d)])
          (if (>= b 0)
-             (list (/ (* 2 c) (- (- b) sqrt-d))
-                   (/ (- (- b) sqrt-d) (* 2 a)))
-             (list (/ (* 2 c) (+ (- b) sqrt-d))
-                   (/ (+ (- b) sqrt-d) (* 2 a)))))])))
+             (list (/ (- (- b) sqrt-d) (* 2 a))
+                   (/ (* 2 c) (- (- b) sqrt-d)))
+             (list (/ (+ (- b) sqrt-d) (* 2 a))
+                   (/ (* 2 c) (+ (- b) sqrt-d)))))])))
 
 (: quadratic-integer-solutions : Real Real Real -> (Listof Integer))
 (define (quadratic-integer-solutions a b c)

--- a/math-lib/math/private/number-theory/quadratic.rkt
+++ b/math-lib/math/private/number-theory/quadratic.rkt
@@ -37,7 +37,6 @@
               [q    (/ (+ b (* sign sqrt-d)) -2)])
          (list (/ q a) (/ c q)))])))
 
-
 (: quadratic-solutions : Real Real Real -> (Listof Real))
 (define (quadratic-solutions a b c)
   ; return list of solutions to a a x^2 + b x + c = 0
@@ -47,8 +46,11 @@
       [(= d 0) (list (/ b (* -2 a)))]
       [else
        (let ([sqrt-d (sqrt d)])
-         (list (/ (- (- b) sqrt-d) (* 2 a))
-               (/ (+ (- b) sqrt-d) (* 2 a))))])))
+         (if (>= b 0)
+             (list (/ (* 2 c) (- (- b) sqrt-d))
+                   (/ (- (- b) sqrt-d) (* 2 a)))
+             (list (/ (* 2 c) (+ (- b) sqrt-d))
+                   (/ (+ (- b) sqrt-d) (* 2 a)))))])))
 
 (: quadratic-integer-solutions : Real Real Real -> (Listof Integer))
 (define (quadratic-integer-solutions a b c)

--- a/math-test/math/tests/number-theory-tests.rkt
+++ b/math-test/math/tests/number-theory-tests.rkt
@@ -9,6 +9,8 @@
 (check-equal? (quadratic-solutions 1 0 -4) '(-2 2))
 (check-equal? (quadratic-solutions 1 0 +4) '())
 (check-equal? (quadratic-solutions 1 0 0)  '(0))
+(check-equal? (quadratic-solutions 1 1e8 1) '(-1e8 -1e-8))
+(check-equal? (quadratic-solutions 1e-8 1 1e-8) '(-99999999.99999999 -1.0000000000000002e-08))
 (check-equal? (quadratic-integer-solutions 1 0 -4) '(-2 2))
 (check-equal? (quadratic-integer-solutions 1 0 +4) '())
 (check-equal? (quadratic-integer-solutions 1 0 0)  '(0))


### PR DESCRIPTION
This is in response to the issue https://github.com/racket/math/issues/16 . Previously, it did not deal well with situation where the linear coefficient was many orders of magnitude larger than the constant or quadratic coefficient. 

See the post linked by @soegaard in the issue for a description of the issue. I confirmed the behavior before reimplementing.

By the way, this is my first pull request, so I'm happy to hear any guidance or feedback on this.