### PR TITLE
Add matrix-kronecker (Kronecker product)

### DIFF
--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -409,6 +409,13 @@ where each entry in @racket[M] is multiplied with @racket[z].
                  (matrix-scale (matrix [[1 2] [3 4]]) 2)]
 }
 
+@defproc[(matrix-kronecker [M (Matrix Number)] [N (Matrix Number)] ...) (Matrix Number)]{
+Computes the Kronecker product.
+@examples[#:eval untyped-eval
+                 (matrix-kronecker (matrix [[1 2] [3 4] [5 6]])
+                                   (matrix [[7 8] [9 10]]))]
+}
+
 @defproc*[([(matrix-map [f (A -> R)] [M (Matrix A)]) (Matrix R)]
            [(matrix-map [f (A B Ts ... -> R)] [M0 (Matrix A)] [M1 (Matrix B)] [N (Matrix Ts)]
                         ...)

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -410,6 +410,7 @@ where each entry in @racket[M] is multiplied with @racket[z].
 }
 
 @defproc[(matrix-kronecker [M (Matrix Number)] [N (Matrix Number)] ...) (Matrix Number)]{
+@margin-note*{Wikipedia: @hyperlink["https://en.wikipedia.org/wiki/Kronecker_product"]{Kronecker product}}
 Computes the Kronecker product.
 @examples[#:eval untyped-eval
                  (matrix-kronecker (matrix [[1 2] [3 4] [5 6]])

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -414,6 +414,7 @@ Computes the Kronecker product.
 @examples[#:eval untyped-eval
                  (matrix-kronecker (matrix [[1 2] [3 4] [5 6]])
                                    (matrix [[7 8] [9 10]]))]
+@history[#:added "1.2"]
 }
 
 @defproc*[([(matrix-map [f (A -> R)] [M (Matrix A)]) (Matrix R)]

--- a/math-lib/info.rkt
+++ b/math-lib/info.rkt
@@ -19,4 +19,4 @@
 
 (define pkg-authors '(ntoronto))
 
-(define version "1.1")
+(define version "1.2")

--- a/math-lib/math/matrix.rkt
+++ b/math-lib/math/matrix.rkt
@@ -8,7 +8,8 @@
          "private/matrix/matrix-comprehension.rkt"
          "private/matrix/matrix-types.rkt"
          "private/matrix/matrix-2d.rkt"
-         ;;"private/matrix/matrix-expt.rkt"  ; all use require/untyped-contract
+         ;;"private/matrix/matrix-expt.rkt"        ; all use require/untyped-contract
+         ;;"private/matrix/matrix-kronecker.rkt"   ; all use require/untyped-contract
          ;;"private/matrix/matrix-gauss-elim.rkt"  ; all use require/untyped-contract
          (except-in "private/matrix/matrix-solve.rkt"
                     matrix-determinant
@@ -47,6 +48,11 @@
  (begin (require "private/matrix/matrix-types.rkt"))
  "private/matrix/matrix-expt.rkt"
  [matrix-expt  ((Matrix Number) Integer -> (Matrix Number))])
+
+(require/untyped-contract
+ (begin (require "private/matrix/matrix-types.rkt"))
+ "private/matrix/matrix-kronecker.rkt"
+ [matrix-kronecker ((Matrix Number) (Matrix Number) * -> (Matrix Number))])
 
 (require/untyped-contract
  (begin (require "private/matrix/matrix-types.rkt"
@@ -172,6 +178,8 @@
           "private/matrix/matrix-2d.rkt")
          ;; matrix/matrix-expt.rkt
          matrix-expt
+         ;; matrix/matrix-kronecker.rkt
+         matrix-kronecker
          ;; matrix-gauss-elim.rkt
          matrix-gauss-elim
          matrix-row-echelon

--- a/math-lib/math/private/matrix/matrix-kronecker.rkt
+++ b/math-lib/math/private/matrix/matrix-kronecker.rkt
@@ -1,0 +1,36 @@
+#lang typed/racket/base
+
+(require "matrix-types.rkt"
+         "matrix-comprehension.rkt"
+         "matrix-basic.rkt"
+         "utils.rkt")
+
+(provide matrix-kronecker)
+
+;; Based on Tim Brown's code. Used with permission.
+(: matrix-kronecker/2 (All (A) ((Matrix A) (Matrix A) (A A -> A) -> (Matrix A))))
+(define (matrix-kronecker/2 a b ×)
+  (define-values (row-a col-a) (matrix-shape a))
+  (define-values (row-b col-b) (matrix-shape b))
+  (define row-out (* row-a row-b))
+  (define col-out (* col-a col-b))
+  (for*/matrix: row-out col-out ([r (in-range row-out)] [c (in-range col-out)]) : A
+    (define-values (index-row-a index-row-b) (quotient/remainder r row-b))
+    (define-values (index-col-a index-col-b) (quotient/remainder c col-b))
+    (× (matrix-ref a index-row-a index-col-a) (matrix-ref b index-row-b index-col-b))))
+
+(: matrix-kronecker/ns
+   (case-> ((Matrix Flonum) (Listof (Matrix Flonum)) -> (Matrix Flonum))
+           ((Matrix Real) (Listof (Matrix Real)) -> (Matrix Real))
+           ((Matrix Float-Complex) (Listof (Matrix Float-Complex)) -> (Matrix Float-Complex))
+           ((Matrix Number) (Listof (Matrix Number)) -> (Matrix Number))))
+(define (matrix-kronecker/ns a as)
+  (for/fold ([result a]) ([x (in-list as)])
+    (matrix-kronecker/2 result x *)))
+
+(: matrix-kronecker
+   (case-> ((Matrix Flonum) (Matrix Flonum) * -> (Matrix Flonum))
+           ((Matrix Real) (Matrix Real) * -> (Matrix Real))
+           ((Matrix Float-Complex) (Matrix Float-Complex) * -> (Matrix Float-Complex))
+           ((Matrix Number) (Matrix Number) * -> (Matrix Number))))
+(define (matrix-kronecker a . as) (call/ns (λ () (matrix-kronecker/ns a as))))

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -435,6 +435,21 @@
   (check-exn exn:fail:contract? (λ () (matrix-expt a 0))))
 
 ;; ===================================================================================================
+;; Kronecker product
+
+(check-equal? (matrix-kronecker (matrix [[1 2]
+                                         [3 4]
+                                         [5 6]])
+                                (matrix [[7 8]
+                                         [9 10]]))
+              (matrix [[7 8 14 16]
+                       [9 10 18 20]
+                       [21 24 28 32]
+                       [27 30 36 40]
+                       [35 40 42 48]
+                       [45 50 54 60]]))
+
+;; ===================================================================================================
 ;; Comprehensions
 
 ;; for:/matrix and friends are defined in terms of for:/array and friends, so we only need to test


### PR DESCRIPTION
This PR adds `matrix-kronecker` function which computes the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product). The implementation is based on @tim-brown's code and it's used with permission.