### PR TITLE
Fix make-odd-flpolyfun

### DIFF
--- a/math-lib/math/private/flonum/flonum-polyfun.rkt
+++ b/math-lib/math/private/flonum/flonum-polyfun.rkt
@@ -38,7 +38,7 @@
     [(_ (c0:expr c:expr ...))
      (syntax/loc stx
        (λ: ([z : Float])
-         (fl+ c0 (fl* z ((make-polyfun (c ...)) (fl* z z))))))]))
+         (fl+ c0 (fl* z ((make-flpolyfun (c ...)) (fl* z z))))))]))
 
 (define-syntax (make-quotient-flpolyfun stx)
   (syntax-parse stx


### PR DESCRIPTION
Fix a small error in `make-odd-flpolyfun` reported by @dieggsy. Closes https://github.com/racket/math/issues/23

(It is currently an unused macro, so the bad identifier is never used and does not produce an error a compilation time.)