### PR TITLE
Switched arguments for bfatan2

### DIFF
--- a/math-doc/math/scribblings/math-bigfloat.scrbl
+++ b/math-doc/math/scribblings/math-bigfloat.scrbl
@@ -576,7 +576,7 @@ Computes @racket[x]@superscript{@racket[y]}. See @racket[flexpt] and @racket[exp
               @defproc[(bfasin [x Bigfloat]) Bigfloat]
               @defproc[(bfacos [x Bigfloat]) Bigfloat]
               @defproc[(bfatan [x Bigfloat]) Bigfloat]
-              @defproc[(bfatan2 [x Bigfloat] [y Bigfloat]) Bigfloat])]{
+              @defproc[(bfatan2 [y Bigfloat] [x Bigfloat]) Bigfloat])]{
 Standard trigonometric functions and their inverses.
 }
 


### PR DESCRIPTION
`bfatan2`  works as `atan` with two arguments.
`(bfatan2 (bf y) (bf x))` ~ `(atan y x)`
Since no extra information is given, I think it's best to keep y and x as in most standard interpretations, and as how it is explained in `atan`.