### PR TITLE
fix memory-management problem in gmp helper for bigfloats

### DIFF
--- a/math-lib/math/private/bigfloat/gmp.rkt
+++ b/math-lib/math/private/bigfloat/gmp.rkt
@@ -114,7 +114,9 @@
 ;; Converts an mpz_t to a Racket integer.
 (define (mpz->integer z)
   (if (zero? (mpz-fits-long? z))
-      (size+limbs->integer (mpz-size z) (mpz-limbs z))
+      (begin0
+        (size+limbs->integer (mpz-size z) (mpz-limbs z))
+        (void/reference-sink z))
       (mpz-get-si z)))
 
 ;; ===================================================================================================

--- a/math-lib/math/private/bigfloat/mpfr.rkt
+++ b/math-lib/math/private/bigfloat/mpfr.rkt
@@ -211,7 +211,7 @@
        (current-directory))))
 
 ;; _mpfr: a multi-precision float with rounding (the main data type)
-(define-cstruct _mpfr ([prec _prec_t] [sign _sign_t] [exp _exp_t] [d _gcpointer])
+(define-cstruct _mpfr ([prec _prec_t] [sign _sign_t] [exp _exp_t] [d _pointer])
   #:property prop:custom-print-quotable 'never
   #:property prop:custom-write (λ (b port mode) (bigfloat-custom-write b port mode))
   #:property prop:equal+hash (list bigfloat-equal? bigfloat-hash bigfloat-hash)


### PR DESCRIPTION
Intended to fix #49.

The additional commit cleans up a CS-specific detail that confused me while debugging.