### PR TITLE
increase accuracy of log1p

### DIFF
--- a/math-lib/math/private/flonum/expansion/expansion-exp-reduction.rkt
+++ b/math-lib/math/private/flonum/expansion/expansion-exp-reduction.rkt
@@ -4,7 +4,7 @@
 The constants used for argument reduction in flexp/error and flexpm1/error
 |#
 
-(require "../../../base.rkt"
+(require (only-in racket/math exact-floor)
          "../flonum-constants.rkt"
          "../flonum-functions.rkt")
 

--- a/math-lib/math/private/flonum/flonum-log.rkt
+++ b/math-lib/math/private/flonum/flonum-log.rkt
@@ -23,51 +23,54 @@
   ;; Computes the value of log(1+x) in a way that is accurate for small x
   (define fllog1p
     (let ([expm1-min 0.0005])
-      (define (taylor-1to5 [x : Flonum]) : Flonum
-        (fl* x (fl+ 0.5 (fl* x (fl+ #i1/6 (fl* x (fl+ #i1/24 (fl* x #i1/120))))))))
-      (define taylor8 (make-flpolyfun (1.0 0.5 #i1/6 #i1/24 #i1/120 #i1/720 #i1/5040 #i1/40320)))
-      (define taylor (λ ([x : Flonum]) (* x (taylor8 x))))
-      (define (flexpm1/error [x : Flonum]) : (Values Flonum Flonum)
-        (cond
-          [((flabs x) . fl< . expm1-min)
-           ;; Taylor, first term in double-double precision - near zero - 5 terms
-           (let*-values ([(x-hi x-lo)  (flsplit x)]
-                         [(y2)     (taylor-1to5 x)]
-                         [(y2 y1)  (fl+/error y2 1.0)])
-             (fl2*split-fl y2 y1 x-hi x-lo))]
-          [else
-           (let*-values ([(x2 d2 d1)  (flexpm1-reduction x)]
-                         [(r2) (taylor x2)];we only need the upper part
-                         [(w2 w1)  (fl+/error r2 1.0)]
-                         [(y2 y1)  (fl2* d2 d1 w2 w1)])
-             (fl2+ y2 y1 r2))]))
-      (λ (x)
-        (define ax (flabs x))
-        (cond
-          [(fl= x -1.0) -inf.0]
-          [(fl< x -1.0) +nan.0]
-          [(flinfinite? x) +inf.0]
-          [(ax . fl>= . 4.0)  (fllog (fl+ 1.0 x))] ;; <= change boundary
-          [(ax . fl<= . (fl* 0.5 epsilon.0)) x]
-          [(x  . fl<= . -0.5)
-           (define y (fl+ 1.0 x))
-           (fl- (fllog y) (fl/ (fl- (fl- y 1.0) x) y))]
-          ;; calculate in fl2
-          [else
-           (define x+1 (fl+ 1.0 x))
-           (define-values (y2 y1)
-             ;; Gutted fl2log, to not do more fl2 computations than necessary
-             (let*-values
-                 ;; Estimate log(x) and do a Newton iteration using expm1
-                 ([(y)       (fllog x+1)]
-                  [(x*)      (fl- x+1 1.0)];= x
-                  [(z2 z1)   (flexpm1/error y)];; => expensive!
-                  [(w2)      (fl+ z2 1.0)]
-                  [(dy2)     (fl- (fl- x* z2) z1)]
-                  [(dy2 dy1) (fl//error dy2 w2)]
-                  [(v1 v2)   (fl+/error y dy2)])
-               (values v1 (fl+ v2 dy1))))
-           (fl- y2 (fl- (fl/ (fl- (fl- x+1 1.0) x) x+1) y1))]))))
+    ;; Taylor approximation for expm1 of 8 terms
+    (define taylor8 (make-flpolyfun (1.0 0.5 #i1/6 #i1/24 #i1/120 #i1/720 #i1/5040 #i1/40320)))
+    (define taylor (λ ([x : Flonum]) (* x (taylor8 x))))
+    (λ (x)
+      (define ax (flabs x))
+      (cond
+        [(fl= x -1.0) -inf.0]
+        [(fl< x -1.0) +nan.0]
+        [(flinfinite? x) +inf.0]
+        [(ax . fl>= . 4.0)  (fllog (fl+ 1.0 x))] ;; <= change boundary
+        [(ax . fl<= . (fl* 0.5 epsilon.0)) x]
+        [(x  . fl<= . -0.5)
+         (define y (fl+ 1.0 x))
+         (fl- (fllog y) (fl/ (fl- (fl- y 1.0) x) y))]
+        ;; calculate in fl2
+        [(ax . fl< . expm1-min)
+         ;; Gutted fl2log, to not do more fl2 computations than necessary
+         (let*-values
+             ([(x+1)      (fl+ x 1.0)]
+              [(x*)       (fl- x+1 1.0)]
+              ;; do a Newton iteration using expm1
+              ;; 0+y+d is a Taylor approximation for expm1, d=terms 2 to 5
+              [(y)        (fllog x+1)]
+              [(d) (fl* y (fl* y (fl+ 0.5 (fl* y (fl+ #i1/6 (fl* y (fl+ #i1/24 (fl* y #i1/120))))))))]
+              ;; fast-fl//error is ok since both arguments are expected in range [1e-35 1e2]
+              [(dy2 dy1)  (fast-fl//error (fl- (fl- x* y) d)
+                                          (fl+ (fl+ y d) 1.0))]
+              ;; fast-mono-fl+/error is ok since |y| > |dy2|
+              [(y2 y1)    (fast-mono-fl+/error y dy2)])
+           (fl- y2 (fl- (fl/ (fl- x* x) x+1) (fl+ y1 dy1))))]
+        [else
+         ;; Gutted fl2log, to not do more fl2 computations than necessary
+         (let*-values
+             ;; Estimate log(x) and do a Newton iteration using expm1
+             ([(x+1)      (fl+ x 1.0)]
+              [(x*)       (fl- x+1 1.0)]
+              [(y)        (fllog x+1)]
+              [(x2 d2 d1) (flexpm1-reduction y)]
+              [(r2)       (taylor x2)];
+              [(w2 w1)    (fast-mono-fl+/error 1.0 r2)]
+              ;; faster than fl2* and accurate 'enough'
+              [(u2 u1)    (fast-fl*/error d2 w2)]
+              [(z2 z1)    (fast-mono-fl+/error u2 r2)]
+              [(dy2 dy1)  (fast-fl//error (fl- (fl- x* z2)
+                                               (fl+ z1 (fl+ (fl+ u1 (fl* w2 d1)) (fl* d2 w1))))
+                                          (fl+ z2 1.0))]
+              [(y2 y1)    (fast-mono-fl+/error y dy2)])
+           (fl- y2 (fl- (fl/ (fl- x* x) x+1) (fl+ y1 dy1))))]))))
   
   (: fllog+ (Flonum Flonum -> Flonum))
   ;; Computes log(a+b) in a way that is accurate for a+b near 1.0

--- a/math-lib/math/private/flonum/flonum-log.rkt
+++ b/math-lib/math/private/flonum/flonum-log.rkt
@@ -27,11 +27,11 @@
       ;; don't put the first term (1.0) in the poly since to much accuracy will be lost
       (define taylor-log1p-7terms
         (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7))])
-          (λ ([x : Flonum]) (fl+ x (fl* x (taylor x))))))
+          (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
       (define taylor-log1p-16terms
         (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7 #i-1/8 #i1/9
                                        #i-1/10 #i1/11 #i-1/12 #i1/13 #i-1/14 #i1/15 #i-1/16))])
-          (λ ([x : Flonum]) (fl+ x (fl* x (taylor x))))))
+          (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
     ;; Taylor approximation for expm1 of 8 terms
     (define taylor-expm1-8terms
       (let ([taylor (make-flpolyfun (1.0 0.5 #i1/6 #i1/24 #i1/120 #i1/720 #i1/5040 #i1/40320))])

--- a/math-lib/math/private/flonum/flonum-log.rkt
+++ b/math-lib/math/private/flonum/flonum-log.rkt
@@ -22,50 +22,81 @@
   (: fllog1p (Float -> Float))
   ;; Computes the value of log(1+x) in a way that is accurate for small x
   (define fllog1p
-    (let ([epsilon.0/2 (fl* 0.5 epsilon.0)])
-      ;; Taylor approximation for log1p.
-      ;; don't put the first term (1.0) in the poly since to much accuracy will be lost
-      (define taylor-log1p-7terms
-        (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7))])
-          (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
-      (define taylor-log1p-16terms
-        (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7 #i-1/8 #i1/9
-                                       #i-1/10 #i1/11 #i-1/12 #i1/13 #i-1/14 #i1/15 #i-1/16))])
-          (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
-    ;; Taylor approximation for expm1 of 8 terms
-    (define taylor-expm1-8terms
-      (let ([taylor (make-flpolyfun (1.0 0.5 #i1/6 #i1/24 #i1/120 #i1/720 #i1/5040 #i1/40320))])
-        (λ ([x : Flonum]) (* x (taylor x)))))
+  (let ([epsilon.0/2 (fl* 0.5 epsilon.0)])
+    ;; approximation for log1p around 0.
+    ;; don't put the first term (1.0) in the poly since too much accuracy will be lost
+    (define taylor-0-to-1e-3
+      (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7))])
+        (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
+    (define taylor-0-to-1e-1
+      (let ([taylor (make-flpolyfun (#i-1/2 #i1/3 #i-1/4 #i1/5 #i-1/6 #i1/7 #i-1/8 #i1/9
+                                            #i-1/10 #i1/11 #i-1/12 #i1/13 #i-1/14 #i1/15 #i-1/16))])
+        (λ ([x : Flonum]) (fl+ x (fl* x (fl* x (taylor x)))))))
+
+    (define (normal [x : Flonum])
+      (define y (fl+ 1.0 x))
+      (fl- (fllog y) (fl/ (fl- (fl- y 1.0) x) y)))
+
+    ;; remap (log1p x) to (+ (log n) (log1p (/ (- x (- n 1)) n)))
+    ;; f2/f1 = (fl2 (bigfloat->real (bflog (bf n))))
+    (define (make-remap [n : Flonum][f2 : Flonum][f1 : Flonum])
+      (define m (- n 1))
+      (λ ([x : Flonum])
+        (define x* (fl/ (fl- x m) n))
+        (define ax* (flabs x*))
+        (define y (if (ax* . fl<= . epsilon.0/2)
+                      x*
+                      (if (ax* . fl<= . 1e-3)
+                          (taylor-0-to-1e-3 x*)
+                          (taylor-0-to-1e-1 x*))))
+        (fl+ f2 (fl+ y f1))))
+    
+    (define remap-0 (make-remap 0.88671875 -0.1202274269981598   2.8375497328444e-18))
+    (define remap-1 (make-remap 0.828125   -0.18859116980755003  7.432164219196925e-18))
+    (define remap-2 (make-remap 0.7734375  -0.2569104137850272  -2.502843296152504e-17))
+    (define remap-3 (make-remap 0.69140625 -0.36902771190573336  2.4362468710901017e-17))
+    (define remap-4 (make-remap 0.625      -0.4700036292457356   2.3229412495470032e-17))
+
+    (define remap+0 (make-remap 1.125  0.11778303565638346 -1.1971685747593677e-18))
+    (define remap+1 (make-remap 1.1875 0.17185025692665923 -6.0224538210113705e-18))
+    (define remap+2 (make-remap 1.25   0.22314355131420976 -9.091270597324799e-18))
+    (define remap+3 (make-remap 1.375  0.3184537311185346   2.7114779367326236e-17))
+    (define remap+4 (make-remap 1.5    0.4054651081081644  -2.8811380259626426e-18))
+    (define remap+5 (make-remap 1.75   0.5596157879354227   2.685492580212308e-17))
+    (define remap+6 (make-remap 2.0    0.6931471805599453   2.3190468138462996e-17))
+    (define remap+7 (make-remap 2.5    0.9162907318741551  -4.141195369011963e-17))
+    (define remap+8 (make-remap 3.0    1.0986122886681098  -9.07129723500153e-17))
+    (define remap+9 (make-remap 3.5    1.252762968495368   -6.097690852192957e-17))
+    (define remap+a (make-remap 4.4375 1.490091154801534    9.349202385763595e-17))
+    
     (λ (x)
       (define ax (flabs x))
       (cond
         [(ax . fl>= . 4.0)  (fllog (fl+ 1.0 x))] ;; <= change boundary
         [(ax . fl<= . epsilon.0/2) x]
-        [(ax . fl<= . 1e-3) (taylor-log1p-7terms x)]
-        [(ax . fl<= . 1e-1) (taylor-log1p-16terms x)]
+        [(ax . fl<= . 1e-3) (taylor-0-to-1e-3 x)]
+        [(ax . fl<= . 1e-1) (taylor-0-to-1e-1 x)]
         [(x  . fl=  . -1.0) -inf.0]
-        [(x  . fl<= . -0.5)
-         (define y (fl+ 1.0 x))
-         (fl- (fllog y) (fl/ (fl- (fl- y 1.0) x) y))]
-        ;; calculate in fl2
-        [else
-         ;; Gutted fl2log, to not do more fl2 computations than necessary
-         (let*-values
-             ;; Estimate log(x) and do a Newton iteration using expm1
-             ([(x+1)      (fl+ x 1.0)]
-              [(x*)       (fl- x+1 1.0)]
-              [(y)        (fllog x+1)]
-              [(x2 d2 d1) (flexpm1-reduction y)]
-              [(r2)       (taylor-expm1-8terms x2)];
-              [(w2 w1)    (fast-mono-fl+/error 1.0 r2)]
-              ;; faster than fl2* and accurate 'enough'
-              [(u2 u1)    (fast-fl*/error d2 w2)]
-              [(z2 z1)    (fast-mono-fl+/error u2 r2)]
-              [(dy2 dy1)  (fast-fl//error (fl- (fl- x* z2)
-                                               (fl+ z1 (fl+ (fl+ u1 (fl* w2 d1)) (fl* d2 w1))))
-                                          (fl+ z2 1.0))]
-              [(y2 y1)    (fast-mono-fl+/error y dy2)])
-           (fl- y2 (fl- (fl/ (fl- x* x) x+1) (fl+ y1 dy1))))]))))
+
+        [(x . fl<= . -0.45)      (normal x)]  ; map at / upper limit
+        [(x . fl<= . -0.3515625) (remap-4 x)] ; #x0.a0 / #x-0.5a
+        [(x . fl<= . -0.2734375) (remap-3 x)] ; #x0.b1 / #x-0.46
+        [(x . fl<= . -0.203125)  (remap-2 x)] ; #x0.c6 / #x-0.34
+        [(x . fl<= . -0.140625)  (remap-1 x)] ; #x0.d4 / #x-0.24
+        [(x . fl<= .  0.0)       (remap-0 x)] ; #x0.e3 / _
+
+        [(x . fl<= .  #x0.28) (remap+0 x)] ; #x1.2 / #x0.28
+        [(x . fl<= .  #x0.38) (remap+1 x)] ; #x1.3 / #x0.38
+        [(x . fl<= .  #x0.50) (remap+2 x)] ; #x1.4 / #x0.5
+        [(x . fl<= .  #x0.70) (remap+3 x)] ; #x1.6 / #x0.7
+        [(x . fl<= .  #x0.a0) (remap+4 x)] ; #x1.8 / #x0.a
+        [(x . fl<= .  #x0.e0) (remap+5 x)] ; #x1.c / #x0.e
+        [(x . fl<= .  #x1.40) (remap+6 x)] ; #x2.0 / #x1.4
+        [(x . fl<= .  #x1.c0) (remap+7 x)] ; #x2.8 / #x1.c
+        [(x . fl<= .  #x2.40) (remap+8 x)] ; #x3.0 / #x2.4
+        [(x . fl<= .  #x2.f0) (remap+9 x)] ; #x3.8 / #2.f0
+        [else                 (remap+a x)] ; #x4.4 / #4.0
+        ))))
   
   (: fllog+ (Flonum Flonum -> Flonum))
   ;; Computes log(a+b) in a way that is accurate for a+b near 1.0

--- a/math-lib/math/private/flonum/flonum-log.rkt
+++ b/math-lib/math/private/flonum/flonum-log.rkt
@@ -6,6 +6,9 @@
          "flonum-constants.rkt"
          "flonum-exp.rkt"
          "flonum-error.rkt"
+         "flonum-polyfun.rkt"
+         "expansion/expansion-base.rkt"
+         "expansion/expansion-exp-reduction.rkt"
          "flvector.rkt")
 
 (provide fllog1p fllog+
@@ -18,13 +21,53 @@
   
   (: fllog1p (Float -> Float))
   ;; Computes the value of log(1+x) in a way that is accurate for small x
-  (define (fllog1p x)
-    (define ax (flabs x))
-    (cond [(ax . fl>= . 1.0)  (fllog (fl+ 1.0 x))]
-          [(ax . fl>= . (fl* 0.5 epsilon.0))
+  (define fllog1p
+    (let ([expm1-min 0.0005])
+      (define (taylor-1to5 [x : Flonum]) : Flonum
+        (fl* x (fl+ 0.5 (fl* x (fl+ #i1/6 (fl* x (fl+ #i1/24 (fl* x #i1/120))))))))
+      (define taylor8 (make-flpolyfun (1.0 0.5 #i1/6 #i1/24 #i1/120 #i1/720 #i1/5040 #i1/40320)))
+      (define taylor (λ ([x : Flonum]) (* x (taylor8 x))))
+      (define (flexpm1/error [x : Flonum]) : (Values Flonum Flonum)
+        (cond
+          [((flabs x) . fl< . expm1-min)
+           ;; Taylor, first term in double-double precision - near zero - 5 terms
+           (let*-values ([(x-hi x-lo)  (flsplit x)]
+                         [(y2)     (taylor-1to5 x)]
+                         [(y2 y1)  (fl+/error y2 1.0)])
+             (fl2*split-fl y2 y1 x-hi x-lo))]
+          [else
+           (let*-values ([(x2 d2 d1)  (flexpm1-reduction x)]
+                         [(r2) (taylor x2)];we only need the upper part
+                         [(w2 w1)  (fl+/error r2 1.0)]
+                         [(y2 y1)  (fl2* d2 d1 w2 w1)])
+             (fl2+ y2 y1 r2))]))
+      (λ (x)
+        (define ax (flabs x))
+        (cond
+          [(fl= x -1.0) -inf.0]
+          [(fl< x -1.0) +nan.0]
+          [(flinfinite? x) +inf.0]
+          [(ax . fl>= . 4.0)  (fllog (fl+ 1.0 x))] ;; <= change boundary
+          [(ax . fl<= . (fl* 0.5 epsilon.0)) x]
+          [(x  . fl<= . -0.5)
            (define y (fl+ 1.0 x))
            (fl- (fllog y) (fl/ (fl- (fl- y 1.0) x) y))]
-          [else  x]))
+          ;; calculate in fl2
+          [else
+           (define x+1 (fl+ 1.0 x))
+           (define-values (y2 y1)
+             ;; Gutted fl2log, to not do more fl2 computations than necessary
+             (let*-values
+                 ;; Estimate log(x) and do a Newton iteration using expm1
+                 ([(y)       (fllog x+1)]
+                  [(x*)      (fl- x+1 1.0)];= x
+                  [(z2 z1)   (flexpm1/error y)];; => expensive!
+                  [(w2)      (fl+ z2 1.0)]
+                  [(dy2)     (fl- (fl- x* z2) z1)]
+                  [(dy2 dy1) (fl//error dy2 w2)]
+                  [(v1 v2)   (fl+/error y dy2)])
+               (values v1 (fl+ v2 dy1))))
+           (fl- y2 (fl- (fl/ (fl- (fl- x+1 1.0) x) x+1) y1))]))))
   
   (: fllog+ (Flonum Flonum -> Flonum))
   ;; Computes log(a+b) in a way that is accurate for a+b near 1.0


### PR DESCRIPTION
fllog1p does not deliver on it's promise to keep it's flulp-error below 1 [#L136](https://github.com/racket/math/blob/58f5d6205abeec854b47a6c70d613089f108bceb/math-doc/math/scribblings/math-flonum.scrbl#L136):
![untitled1](https://user-images.githubusercontent.com/6235541/92381428-23749a80-f10b-11ea-9e38-26aac9e70a54.png)
![untitled2](https://user-images.githubusercontent.com/6235541/92381434-27082180-f10b-11ea-9347-b835276b3c05.png)
![untitled3](https://user-images.githubusercontent.com/6235541/92381441-28d1e500-f10b-11ea-9425-33fe80dd0af1.png)
![untitled4](https://user-images.githubusercontent.com/6235541/92381443-2a031200-f10b-11ea-96b3-8cf86e774569.png)
![untitled5](https://user-images.githubusercontent.com/6235541/92381447-2bccd580-f10b-11ea-8cd6-db040d7f7827.png)

Some numbers for 1million numbers generated between 2^-17 and 4.1e0:

flulp-error | old | new
-- | -- | --
<0.5 | 74.1% | 99.60%
<0.6 | 8.4% | 0.40%
<0.7 | 7.0% |  
<1 | 10.0% |  
<1.5 | 0.5% |  


Unfortunatly the speed impact is quite severe:

  | old | new
-- | -- | --
1e8 flonums in the range 2^-17 to 4.1e0 | 200ms | 6700ms
1e8 flonums in the range 2^-300 to 4.1e0 | 100ms | 1100ms
1e8 flonums in the range 2^-300 to 2^300 | 200ms | 700ms

