### PR TITLE
modular-expt: performance improvements

### DIFF
--- a/math-lib/math/private/number-theory/modular-arithmetic-base.rkt
+++ b/math-lib/math/private/number-theory/modular-arithmetic-base.rkt
@@ -49,12 +49,14 @@
   ;; Exponentiate by repeated modular multiplication and squaring
   (define (modular-expt* n a b)
     (cond [(b . < . 0)  (raise-argument-error 'modular-expt "Natural" 1 a b n)]
+          [(b . = . 0)  (if (n . = . 1) 0 1)]
           [else
-           (let loop ([a a] [b b])
-             (cond [(b . <= . 1)  (if (zero? b) (modulo 1 n) (modulo a n))]
-                   [(even? b)  (define c (loop a (quotient b 2)))
-                               (modulo (* c c) n)]
-                   [else  (modulo (* a (loop a (sub1 b))) n)]))]))
+           (let ([a (modulo a n)])
+             (let loop ([b b])
+               (cond [(b . = . 1)  a]
+                     [(even? b)  (define c (loop (quotient b 2)))
+                                 (modulo (* c c) n)]
+                     [else  (modulo (* a (loop (sub1 b))) n)])))]))
   
   (: modular-const* (Positive-Integer Exact-Rational -> Natural))
   (define (modular-const* n a)


### PR DESCRIPTION
First, if `b` > 0, then in the loop, `b` will never reach 0, so we can
lift the case where `b` = 0 up over the loop. The answer in this case is
either 0 or 1, depending on the value of `n`.

Second, we can use `(modulo a n)` in multiplication. 
This avoids computing large multiplication `(* a ...)` in the odd exponent case.

For example:

```
(define N 100000)

(define a (expt 2 N))
(define b (expt 3 N))
(define n 1000003)

(time (modular-expt a b n))
```

currently outputs:

```
cpu time: 5816 real time: 5816 gc time: 54
```

With the PR, it outputs:

```
cpu time: 3446 real time: 3446 gc time: 58
```