### PR TITLE
Add more explicit references to primality tests

### DIFF
--- a/math-lib/math/private/number-theory/number-theory.rkt
+++ b/math-lib/math/private/number-theory/number-theory.rkt
@@ -131,6 +131,7 @@
 
 ;;; PRIMALITY TESTS
 
+; From Modern Computer Algebra by Joachim von sur Gathen and Jürgen Gerhard
 ; Strong pseudoprimality test
 ; The strong test returns one of:
 ;   'probably-prime                                        if n is a prime
@@ -192,6 +193,8 @@
 (: prime? : Integer -> Boolean)
 (define prime?
   (let ()
+    ; Sieve of Eratosthenes
+    ; https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
     ; TODO: Only store odd integers in this table
     (define N *VERY-SMALL-PRIME-LIMIT*)
     (define ps (make-vector (+ N 1) #t))

--- a/math-lib/math/private/number-theory/small-primes.rkt
+++ b/math-lib/math/private/number-theory/small-primes.rkt
@@ -6,6 +6,9 @@
  [bit-vector-set! (BitVector Integer Boolean -> Void)]
  [bit-vector-ref  (BitVector Integer -> Boolean)])
 
+; Primality testing using a Sieve of Atkin
+; https://en.wikipedia.org/wiki/Sieve_of_Atkin
+
 (provide small-prime?
          *SMALL-PRIME-LIMIT*)
 


### PR DESCRIPTION
For whatever reason when I initially encountered "MCA" I didn't have such a fun time deciphering what it meant. Likewise with the Sieve of Atkin. I'd like to add more explicit references to what these algorithms are in case anyone else who happens to be reading through the source code would like to know as well.

Perhaps other references could be added throughout the sources, but these were of particular interest to me.