### PR TITLE
Remove unnecessary require in flonum-log

### DIFF
--- a/math-lib/math/private/flonum/flonum-log.rkt
+++ b/math-lib/math/private/flonum/flonum-log.rkt
@@ -8,7 +8,6 @@
          "flonum-error.rkt"
          "flonum-polyfun.rkt"
          "expansion/expansion-base.rkt"
-         "expansion/expansion-exp-reduction.rkt"
          "flvector.rkt")
 
 (provide fllog1p fllog+


### PR DESCRIPTION
6aa87279e15f98b514ffb9827586b4f9e278b0cd introduced it, but 6aa87279e15f98b514ffb9827586b4f9e278b0cd removed the need for it