### PR TITLE
negative exponents allowed in modular-expt

### DIFF
--- a/math-doc/math/scribblings/math-number-theory.scrbl
+++ b/math-doc/math/scribblings/math-number-theory.scrbl
@@ -175,12 +175,13 @@ This function is also known as the @emph{Legendre symbol}.
 
 @defproc[(modular-expt [a Integer] [b Integer] [n Integer]) Natural]{
   Computes @racket[(modulo (expt a b) n)], but much more efficiently. The modulus @racket[n] must
-  be positive, and the exponent @racket[b] must be nonnegative.
+  be positive.
   
   @examples[#:eval untyped-eval
                    (modulo (expt -6 523) 19)
                    (modular-expt -6 523 19)
                    (modular-expt 9 158235208 19)
+                   (modular-expt 2 -1 11)
                    (eval:alts (code:line (code:comment "don't try this at home!")
                                          (modulo (expt 9 158235208) 19))
                               (eval:result @racketresultfont{4}))

--- a/math-lib/math/private/number-theory/modular-arithmetic-base.rkt
+++ b/math-lib/math/private/number-theory/modular-arithmetic-base.rkt
@@ -48,7 +48,7 @@
   (: modular-expt* (Positive-Integer Integer Integer -> Natural))
   ;; Exponentiate by repeated modular multiplication and squaring
   (define (modular-expt* n a b)
-    (cond [(b . < . 0)  (raise-argument-error 'modular-expt "Natural" 1 a b n)]
+    (cond [(b . < . 0)  (modular-expt* n (modular-inverse* n a) (- b))]
           [(b . = . 0)  (if (n . = . 1) 0 1)]
           [else
            (let ([a (modulo a n)])

--- a/math-test/math/tests/number-theory-tests.rkt
+++ b/math-test/math/tests/number-theory-tests.rkt
@@ -253,6 +253,12 @@
 (check-equal? (with-modulus 7 (mod/ 1 3)) 5)
 (check-equal? (with-modulus 7 (mod/ 3)) 5)
 
+(check-equal? (modular-expt 2 8 11) 3)
+(check-equal? (modular-expt 2 -1 19) 10)
+(check-equal? (modular-expt 3 -2 47) 21)  ; PowerMod[3,-2,47]
+(check-equal? (modular-expt 3 -4 47) 18)  ; PowerMod[3,-4,47]
+
+(check-equal (with-modulus 19 (modexpt 2 -1)) 10)
 
 ; "quadratic-residues.rkt"
 (check-equal? (quadratic-character  2 5) -1)


### PR DESCRIPTION
Issue #58 - added the ability to handle negative exponents in `modular-expt*`, tests, and a documentation change.
