### PR TITLE
adapt define-typed/untyped-id to shallow & optional

### DIFF
--- a/math-lib/math/private/array/array-convert.rkt
+++ b/math-lib/math/private/array/array-convert.rkt
@@ -18,10 +18,24 @@
          array->list
          array->vector)
 
+(module shallow-defs typed/racket/shallow
+  (require typed/racket/unsafe "array-struct.rkt" "mutable-array.rkt" "utils.rkt")
+  (provide shallow:list*->array shallow:vector*->array)
+  (unsafe-require/typed "untyped-array-convert.rkt"
+    [(list*->array shallow:list*->array)
+     (All (A) ((Listof* A) ((Listof* A) -> Any : A) -> (Array A)))]
+    [(vector*->array shallow:vector*->array)
+     (All (A) ((Vectorof* A) ((Vectorof* A) -> Any : A) -> (Mutable-Array A)))]))
+(require 'shallow-defs)
+
 (define-typed/untyped-identifier list*->array
   typed:list*->array
-  untyped:list*->array)
+  untyped:list*->array
+  shallow:list*->array
+  shallow:list*->array)
 
 (define-typed/untyped-identifier vector*->array
   typed:vector*->array
-  untyped:vector*->array)
+  untyped:vector*->array
+  shallow:vector*->array
+  shallow:vector*->array)

--- a/math-lib/math/private/array/array-pointwise.rkt
+++ b/math-lib/math/private/array/array-pointwise.rkt
@@ -7,8 +7,19 @@
          (rename-in "untyped-array-pointwise.rkt"
                     [array-map  untyped:array-map]))
 
+(module shallow-defs typed/racket/shallow
+  (require typed/racket/unsafe "array-struct.rkt")
+  (provide shallow:array-map)
+  (unsafe-require/typed "untyped-array-pointwise.rkt"
+    [(array-map shallow:array-map)
+     (All (R A B T ...)
+       (case-> ((-> R) -> (Array R))
+               ((A -> R) (Array A) -> (Array R))
+               ((A B T ... T -> R) (Array A) (Array B) (Array T) ... T -> (Array R))))]))
+(require 'shallow-defs)
+
 (define-typed/untyped-identifier array-map
-  typed:array-map untyped:array-map)
+  typed:array-map untyped:array-map shallow:array-map shallow:array-map)
 
 (define-syntax-rule (define-array-op1 name op)
   (define-syntax-rule (name arr) (array-map op arr)))


### PR DESCRIPTION
Change some `define-typed/untyped-id` forms to work with typed/racket/shallow and typed/racket/optional

Those TR languages are coming in PR 948
 <https://github.com/racket/typed-racket/pull/948>

Let's wait until that's merged to merge this PR.