### PR TITLE
Fix #73 by avoiding rounding error in a fast path

### DIFF
--- a/math-lib/math/private/bigfloat/mpfr.rkt
+++ b/math-lib/math/private/bigfloat/mpfr.rkt
@@ -823,7 +823,7 @@ There's no reason to allocate new limbs for an _mpfr without changing its precis
    [(not (bfinteger? x)) #f]
    [(> exp 0) #t]
    [(= sig 0) #t]
-   [(> (- exp) (log (abs sig) 2)) #t] ; Avoid constructing large "1"s
+   [(> (- exp) (ceiling (log (abs sig) 2))) #t] ; Avoid constructing large "1"s
    [else (= (bitwise-and (abs sig) (expt 2 (- exp))) 0)]))
 
 (define (bfodd? x) (and (bfinteger? x) (not (bfeven? x))))

--- a/math-test/math/tests/bigfloat-tests.rkt
+++ b/math-test/math/tests/bigfloat-tests.rkt
@@ -180,6 +180,10 @@
 (for ([i (in-range -20 20)])
   (check-pred (if (even? i) bfeven? bfodd?) (bf i)))
 
+(parameterize ([bf-precision 8000])
+  (for ([i (in-range -20 20)])
+    (check-pred (if (even? i) bfeven? bfodd?) (bf i))))
+
 ;; Check that bfeven? is fast (<10ms) for large inputs
 (define t (current-inexact-milliseconds))
 (check-true (bfeven? (bfstep +inf.bf -1)))


### PR DESCRIPTION
The `bfodd?` function had a fast-path with a rounding error, which sometimes caused odd numbers to look even. This fixes it.