### PR TITLE
build-array - Prevent double execution of first element

### DIFF
--- a/math-lib/math/private/array/for-each.rkt
+++ b/math-lib/math/private/array/for-each.rkt
@@ -140,5 +140,6 @@
           [else
            (define: js0 : Indexes (make-vector dims 0))
            (define: vs : (Vectorof A) (make-vector size (g js0 0)))
-           (for-each-array+data-index ds (λ (js j) (unsafe-vector-set! vs j (g js j))))
+           (for-each-array+data-index ds (λ (js j)
+                                           (unless (= j 0) (unsafe-vector-set! vs j (g js j)))))
            vs])))

--- a/math-test/math/tests/array-tests.rkt
+++ b/math-test/math/tests/array-tests.rkt
@@ -280,6 +280,11 @@
               (array #[#[#[1.0 0.0] #[0.0 0.0]]
                        #[#[0.0 0.0] #[0.0 1.0]]]))
 
+(check-equal? (let ([count 0])
+                (build-array #(1) (λ (i)(set! count (+ count 1)) i))
+                count)
+              1)
+
 ;; ---------------------------------------------------------------------------------------------------
 ;; Pointwise
 ;; Not much to test here because most pointwise ops are defined by the same two lifts


### PR DESCRIPTION
closes #9

doing some timing tests on different size arrays, the influence of the extra check seems negligible. The only case where there was a consistent difference was for the size=1 array that is now slightly faster.