### PR TITLE
Make `bfeven` rely on `bfshift`

### DIFF
--- a/math-lib/math/private/bigfloat/mpfr.rkt
+++ b/math-lib/math/private/bigfloat/mpfr.rkt
@@ -890,16 +890,17 @@ There's no reason to allocate new limbs for an _mpfr without changing its precis
   (mpfr-nextbelow y)
   y)
 
+
+(define mpfr-mul-2si
+  (get-mpfr-fun 'mpfr_mul_2si (_fun _mpfr-pointer _mpfr-pointer _exp_t _rnd_t -> _int)))
+
 ; Inline an unusual FFI signature redefinition
-(define bfshift
-  (let ([cfun (get-mpfr-fun 'mpfr_mul_2si (_fun _mpfr-pointer _mpfr-pointer _long _rnd_t -> _int))])
-    (procedure-rename
-     (λ (x n)
-       (unless (fixnum? n)
-         (raise-argument-error 'bfshift "Fixnum" 1 x n))
-       (define y (new-mpfr (bigfloat-precision x)))
-       (cfun y x n))
-     'bfshift)))
+(define (bfshift x n)
+  (unless (fixnum? n)
+    (raise-argument-error 'bfshift "Fixnum" 1 x n))
+  (define y (new-mpfr (bigfloat-precision x)))
+  (mpfr-mul-2si y x n (bf-rounding-mode))
+  y)
 
 (define (infinite-ordinal p)
   (+ 1 (arithmetic-shift #b1111111111111111111111111111111 (- p 1))))

--- a/math-test/math/tests/bigfloat-tests.rkt
+++ b/math-test/math/tests/bigfloat-tests.rkt
@@ -123,6 +123,13 @@
     (check-equal? (bfprev 0.bf) -min.bf)
     ))
 
+(check-equal? (bfshift 0.bf -1) 0.bf)
+(check-equal? (bigfloat-signbit (bfshift -0.bf -1)) (bigfloat-signbit -0.bf))
+(check-equal? (bfshift (bfnext 0.bf) -1) 0.bf)
+(check-equal? (bfshift (bfprev +inf.bf) +1) +inf.bf)
+(check-equal? (bfshift +inf.bf -1) +inf.bf)
+
+
 ;; Integer conversion
 
 (check-equal? (bigfloat->integer (integer->bigfloat 0)) 0)


### PR DESCRIPTION
Right now `bfeven?` has tricky logic to determine even/odd based on the exponent and significand. This logic has already caused one bug, and relies on some expensive primitives like `log` for large numbers.

Defining `bfeven?` in terms of `bfshift` is much faster and cleaner: a number `x` is even if `x/2` is an integer.

I also rewrote `bfshift` to call an underlying MPFR function, which should make it a bit faster because it won't need to allocate an integer for the significand. This probably is needless optimization but I suppose why not do it?