### PR TITLE
added matrix-set-col and matrix-set-row

### DIFF
--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -525,8 +525,8 @@ in list must have the same number of columns.
                  (matrix-stack (list M0 M1 M2))]
 }
 
-@deftogether[(@defproc[(matrix-set-col [M (Matrix A)] [new-col (Matrix A)] [idx Integer]) (Matrix A)]
-              @defproc[(matrix-set-row [M (Matrix A)] [new-row (Matrix A)] [idx Integer]) (Matrix A)])]{
+@deftogether[(@defproc[(matrix-set-col [M (Matrix A)] [idx Integer] [new-col (Matrix A)]) (Matrix A)]
+              @defproc[(matrix-set-row [M (Matrix A)] [idx Integer] [new-row (Matrix A)]) (Matrix A)])]{
 
 The function @racket[matrix-set-col] returns a matrix whose @racket[idx]th column is @racket[new-col].
 The function @racket[matrix-set-row] returns a matrix whose @racket[idx]th row is @racket[new-row].
@@ -539,8 +539,8 @@ The function @racket[matrix-set-row] returns a matrix whose @racket[idx]th row i
 		 (define new-col (col-matrix [-1 -2 -3]))
 		 (define new-row (row-matrix [-1 -2 -3]))
 
-		 (matrix-set-column mat new-col 0)
-		 (matrix-set-row mat new-row 0)]
+		 (matrix-set-col mat 0 new-col)
+		 (matrix-set-row mat 0 new-row)]
 }
 
 @deftogether[

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -364,7 +364,7 @@ Like @racket[list*->matrix] and @racket[matrix*->list], but for vectors.
 As in the first example, Typed Racket often needs help inferring the type @racket[A].
 }
 
-                                                                                  
+
 @;{==================================================================================================}
 
 
@@ -377,13 +377,13 @@ Matrix addition, subtraction and products respectively.
 
 For matrix addition and subtraction all matrices must have the same shape.
 
-For matrix product the number of columns of one matrix must equal the 
+For matrix product the number of columns of one matrix must equal the
 number of rows in the following matrix.
 
 @examples[#:eval untyped-eval
-                 (define A (matrix ([1 2] 
+                 (define A (matrix ([1 2]
                                     [3 4])))
-                 (define B (matrix ([5 6] 
+                 (define B (matrix ([5 6]
                                     [7 8])))
                  (define C (matrix ([ 9 10 11]
                                     [12 13 14])))
@@ -403,7 +403,7 @@ Computes @racket[(matrix* M ...)] with @racket[n] arguments, but more efficientl
 }
 
 @defproc[(matrix-scale [M (Matrix Number)] [z Number]) (Matrix Number)]{
-Computes the matrix @racket[zM], a matrix of the same shape as @racket[M] 
+Computes the matrix @racket[zM], a matrix of the same shape as @racket[M]
 where each entry in @racket[M] is multiplied with @racket[z].
 @examples[#:eval untyped-eval
                  (matrix-scale (matrix [[1 2] [3 4]]) 2)]
@@ -487,7 +487,7 @@ Returns array of the entries on the diagonal of @racket[M].
               @defproc[(matrix-lower-triangle [M (Matrix A)] [zero A 0]) (Matrix A)])]{
 The function @racket[matrix-upper-triangle] returns an upper
 triangular matrix (entries below the diagonal have the value @racket[zero]) with
-entries from the given matrix. Likewise the function 
+entries from the given matrix. Likewise the function
 @racket[matrix-lower-triangle] returns a lower triangular
 matrix.
 @examples[#:eval typed-eval
@@ -511,11 +511,11 @@ of the matrix.
 @deftogether[(@defproc[(matrix-augment [Ms (Listof (Matrix A))]) (Matrix A)]
               @defproc[(matrix-stack [Ms (Listof (Matrix A))]) (Matrix A)])]{
 The function @racket[matrix-augment] returns a matrix whose columns are
-the columns of the matrices in @racket[Ms]. The matrices 
+the columns of the matrices in @racket[Ms]. The matrices
 in list must have the same number of rows.
 
 The function @racket[matrix-stack] returns a matrix whose rows are
-the rows of the matrices in @racket[Ms]. The matrices 
+the rows of the matrices in @racket[Ms]. The matrices
 in list must have the same number of columns.
 @examples[#:eval untyped-eval
                  (define M0 (matrix ([1 1] [1 1])))
@@ -525,8 +525,26 @@ in list must have the same number of columns.
                  (matrix-stack (list M0 M1 M2))]
 }
 
+@deftogether[(@defproc[(matrix-set-col [M (Matrix A)] [new-col (Matrix A)] [idx Integer]) (Matrix A)]
+              @defproc[(matrix-set-row [M (Matrix A)] [new-row (Matrix A)] [idx Integer]) (Matrix A)])]{
+
+The function @racket[matrix-set-col] returns a matrix whose @racket[idx]th column is @racket[new-col].
+The function @racket[matrix-set-row] returns a matrix whose @racket[idx]th row is @racket[new-row].
+
+@examples[#:eval untyped-eval
+		 (define mat (matrix [[1 2 3]
+				      [4 5 6]
+				      [7 8 9]]))
+
+		 (define new-col (col-matrix [-1 -2 -3]))
+		 (define new-row (row-matrix [-1 -2 -3]))
+
+		 (matrix-set-column mat new-col 0)
+		 (matrix-set-row mat new-row 0)]
+}
+
 @deftogether[
-(@defproc*[([(matrix-map-rows 
+(@defproc*[([(matrix-map-rows
               [f ((Matrix A) -> (Matrix B))] [M (Matrix A)]) (Matrix B)]
             [(matrix-map-rows
               [f ((Matrix A) -> (U #f (Matrix B)))] [M (Matrix A)] [fail (-> F)])
@@ -552,7 +570,7 @@ returned:
 }
 
 @deftogether[
-(@defproc*[([(matrix-map-cols 
+(@defproc*[([(matrix-map-cols
               [f ((Matrix A) -> (Matrix B))] [M (Matrix A)]) (Matrix B)]
             [(matrix-map-cols
               [f ((Matrix A) -> (U #f (Matrix B)))] [M (Matrix A)] [fail (-> F)])
@@ -577,7 +595,7 @@ Returns a matrix where each entry of the given matrix is conjugated.
               @defproc[(matrix-hermitian [M (Matrix Number)]) (Matrix Number)])]{
 @margin-note*{Wikipedia: @hyperlink["http://en.wikipedia.org/wiki/Transpose"]{Transpose},
                          @hyperlink["http://en.wikipedia.org/wiki/Hermitian_matrix"]{Hermitian}}
-Returns the transpose or the hermitian of the matrix. 
+Returns the transpose or the hermitian of the matrix.
 The hermitian of a matrix is the conjugate of the transposed matrix.
 For a real matrix these operations return the the same result.
 @examples[#:eval untyped-eval
@@ -587,8 +605,8 @@ For a real matrix these operations return the the same result.
 
 @defproc[(matrix-trace [M (Matrix Number)]) Number]{
 @margin-note*{@hyperlink["http://en.wikipedia.org/wiki/Trace_(linear_algebra)"]{Wikipedia: Trace}}
-Returns the trace of the square matrix. The trace of matrix is the 
-the sum of the diagonal entries. 
+Returns the trace of the square matrix. The trace of matrix is the
+the sum of the diagonal entries.
 @examples[#:eval untyped-eval
                  (matrix-trace (matrix ([1 2] [3 4])))]
 }
@@ -622,13 +640,13 @@ The L@subscript{1} norm is also known under the names Manhattan or taxicab norm.
 The L@subscript{1} norm of a matrix is the sum of magnitudes of the entries in the matrix.
 
 The L@subscript{2} norm is also known under the names Euclidean or Frobenius norm.
-The L@subscript{2} norm of a matrix is the square root of the sum of squares of 
+The L@subscript{2} norm of a matrix is the square root of the sum of squares of
 magnitudes of the entries in the matrix.
 
 The L@subscript{∞} norm is also known as the maximum or infinity norm.
 The L@subscript{∞} norm computes the maximum magnitude of the entries in the matrix.
 
-For @racket[p >= 1], @racket[matrix-norm] computes the L@subscript{@racket[p]} norm: 
+For @racket[p >= 1], @racket[matrix-norm] computes the L@subscript{@racket[p]} norm:
 the @racket[p]th root of the sum of all entry magnitudes to the @racket[p]th power.
 @;{MathJax would be nice to have in Scribble...}
 @examples[#:eval untyped-eval
@@ -642,9 +660,9 @@ the @racket[p]th root of the sum of all entry magnitudes to the @racket[p]th pow
 @defproc*[([(matrix-dot [M (Matrix Number)]) Nonnegative-Real]
            [(matrix-dot [M (Matrix Number)] [N (Matrix Number)]) Number])]{
 
-The call @racket[(matrix-dot M N)] computes the Frobenius inner product of the 
+The call @racket[(matrix-dot M N)] computes the Frobenius inner product of the
 two matrices with the same shape.
-In other words the sum of @racket[(* a (conjugate b))] is computed where 
+In other words the sum of @racket[(* a (conjugate b))] is computed where
 @racket[a] runs over the entries in @racket[M] and @racket[b] runs over
 the corresponding entries in @racket[N].
 
@@ -656,7 +674,7 @@ The call @racket[(matrix-dot M)] computes @racket[(matrix-dot M M)] efficiently.
 
 @defproc[(matrix-cos-angle [M (Matrix Number)] [N (Matrix Number)]) Number]{
 Returns the cosine of the angle between two matrices w.r.t. the inner produce space induced by
-the Frobenius inner product. That is it returns 
+the Frobenius inner product. That is it returns
 
 @racket[(/ (matrix-dot M N) (* (matrix-2norm M) (matrix-2norm N)))]
 
@@ -709,8 +727,8 @@ or column in @racket[M] is zero.
               @defproc[(matrix-cols-orthogonal? [M (Matrix Number)]
                                                 [eps Real (* 10 epsilon.0)])
                        Boolean])]{
-Returns @racket[#t] if the rows or columns of @racket[M] 
-are very close of being orthogonal (by default a few epsilons). 
+Returns @racket[#t] if the rows or columns of @racket[M]
+are very close of being orthogonal (by default a few epsilons).
 @examples[#:eval untyped-eval
                  (matrix-rows-orthogonal? (matrix [[1 1] [-1 1]]))
                  (matrix-cols-orthogonal? (matrix [[1 1] [-1 1]]))]
@@ -779,7 +797,7 @@ Returns the determinant of @racket[M], which must be a @racket[square-matrix?].
                  (matrix-determinant (col-matrix [1 2]))]
 }
 
-                                                                                  
+
 @;{==================================================================================================}
 
 
@@ -867,7 +885,7 @@ If @racket[M] does not have an LU decomposition, the first result is the result 
                     (matrix-lu (matrix [[0 1] [1 1]]) (λ () #f))]
 }
 
-                                                                                  
+
 @;{==================================================================================================}
 
 
@@ -884,7 +902,7 @@ The number of columns in the result is the rank of @racket[M].
 If @racket[normalize?] is true, the columns are also normalized.
 
 @examples[#:eval typed-eval
-                 (define M 
+                 (define M
                    (matrix [[12 -51   4]
                             [ 6 167 -68]
                             [-4  24 -41]]))
@@ -935,9 +953,9 @@ the matrices @racket[Q] and @racket[R]. If @racket[full?] is @racket[#f], then
 a reduced decomposition is returned, otherwise a full decomposition is returned.
 
 @margin-note*{An @italic{orthonormal} matrix has columns which are orthoginal, unit vectors.}
-The (full) decomposition of a square matrix consists of two matrices: 
-a orthogonal matrix @racket[Q] and an upper triangular matrix @racket[R], 
-such that @racket[QR = M]. 
+The (full) decomposition of a square matrix consists of two matrices:
+a orthogonal matrix @racket[Q] and an upper triangular matrix @racket[R],
+such that @racket[QR = M].
 
 For tall non-square matrices @racket[R], the triangular part of the full decomposition,
 contains zeros below the diagonal. The reduced decomposition leaves the zeros out.
@@ -966,8 +984,8 @@ The difference between full and reduced decompositions:
                     (matrix= M (matrix* Q1 R1))
                     (matrix= M (matrix* Q2 R2))]
 
-The decomposition @racket[M = QR] is useful for solving the equation @racket[Mx=v]. 
-Since the inverse of Q is simply the transpose of Q, 
+The decomposition @racket[M = QR] is useful for solving the equation @racket[Mx=v].
+Since the inverse of Q is simply the transpose of Q,
   @racket[Mx=v  <=>  QRx=v  <=>  Rx = Q^T v].
 And since @racket[R] is upper triangular, the system can be solved by back substitution.
 
@@ -1001,7 +1019,7 @@ When M is a column matrix, @racket[(matrix-op-1norm M)] is equivalent to @racket
 
 @defproc[(matrix-op-2norm [M (Matrix Number)]) Nonnegative-Real]{
 The @tech{operator norm} induced by the vector norm @racket[matrix-2norm].
-                                             
+
 This function is currently undefined because a required algorithm (singular value decomposition or
 eigendecomposition) is not yet implemented in @racketmodname[math/matrix].
 
@@ -1024,7 +1042,7 @@ eigendecomposition) is not yet implemented in @racketmodname[math/matrix].
 When @racket[M0] and @racket[M1] are column matrices, @racket[(matrix-basis-cos-angle M0 M1)] is
 equivalent to @racket[(matrix-cos-angle M0 M1)].
 }
-         
+
 @defproc[(matrix-basis-angle [M0 (Matrix Number)] [M1 (Matrix Number)]) Number]{
 Equivalent to @racket[(acos (matrix-basis-cos-angle M0 M1))].
 
@@ -1071,7 +1089,7 @@ epsilons). Equivalent to
 @racketblock[(<= (matrix-absolute-error M (make-matrix m n 0)) eps)]
 where @racket[m n] is the shape of @racket[M].
 }
-                         
+
 @defproc[(matrix-identity? [M (Matrix Number)] [eps Real (* 10 epsilon.0)]) Boolean]{
 Returns @racket[#t] when @racket[M] is very close to the identity matrix (by default, within a few
 epsilons).

--- a/math-lib/math/private/matrix/matrix-basic.rkt
+++ b/math-lib/math/private/matrix/matrix-basic.rkt
@@ -36,7 +36,7 @@
  matrix-augment
  matrix-stack
 ;; Setters
- matrix-set-column
+ matrix-set-col
  matrix-set-row
  ;; Inner product space
  matrix-1norm
@@ -196,12 +196,12 @@
 ;; ===================================================================================================
 ;; Setters
 
-(: matrix-set-column (All (A) (Matrix A) (Matrix A) Integer -> (Matrix A)))
-(define (matrix-set-column M new-col idx)
+(: matrix-set-col (All (A) (Matrix A) Integer (Matrix A) -> (Matrix A)))
+(define (matrix-set-col M idx new-col)
   (matrix-augment (list-set (matrix-cols M) idx new-col)))
 
-(: matrix-set-row (All (A) (Matrix A) (Matrix A) Integer -> (Matrix A)))
-(define (matrix-set-row M new-row idx)
+(: matrix-set-row (All (A) (Matrix A) Integer (Matrix A) -> (Matrix A)))
+(define (matrix-set-row M idx new-row)
   (matrix-stack (list-set (matrix-rows M) idx new-row)))
 
 ;; ===================================================================================================

--- a/math-lib/math/private/matrix/matrix-basic.rkt
+++ b/math-lib/math/private/matrix/matrix-basic.rkt
@@ -35,6 +35,9 @@
  ;; Embiggenment
  matrix-augment
  matrix-stack
+;; Setters
+ matrix-set-column
+ matrix-set-row
  ;; Inner product space
  matrix-1norm
  matrix-2norm
@@ -191,6 +194,17 @@
                        (format-matrices/error as))])]))
 
 ;; ===================================================================================================
+;; Setters
+
+(: matrix-set-column (All (A) (Matrix A) (Matrix A) Integer -> (Matrix A)))
+(define (matrix-set-column M new-col idx)
+  (matrix-augment (list-set (matrix-cols M) idx new-col)))
+
+(: matrix-set-row (All (A) (Matrix A) (Matrix A) Integer -> (Matrix A)))
+(define (matrix-set-row M new-row idx)
+  (matrix-stack (list-set (matrix-rows M) idx new-row)))
+
+;; ===================================================================================================
 ;; Inner product space (entrywise norm)
 
 (: nonstupid-magnitude (case-> (Flonum -> Nonnegative-Flonum)
@@ -327,7 +341,7 @@
      (array-strict! M)
      (define x (matrix-norm M p))
      (cond [(and (zero? x) (exact? x))  (fail)]
-           [else  (matrix-scale M (/ x))])]))  
+           [else  (matrix-scale M (/ x))])]))
 
 ;; ===================================================================================================
 ;; Operators
@@ -471,7 +485,7 @@
   (cond [(negative? eps)  (raise-argument-error 'matrix-rows-orthogonal? "Nonnegative-Real" 1 M eps)]
         [else  (parameterize ([array-strictness #f])
                  (pairwise-orthogonal? (matrix-rows M) eps))]))
-         
+
 
 (: matrix-cols-orthogonal? (case-> ((Matrix Number) -> Boolean)
                                    ((Matrix Number) Real -> Boolean)))

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -360,32 +360,32 @@
   (begin
     (for: ([a  (in-list nonmatrices)])
       (check-exn exn:fail:contract? (λ () (matrix* a (matrix [[1]])))))
-    
+
     (check-equal? (matrix* (matrix [[1 2 3] [4 5 6] [7 8 9]])
                            (matrix [[1 2 3] [4 5 6] [7 8 9]]))
                   (matrix [[30 36 42] [66 81 96] [102 126 150]]))
-    
+
     (check-equal? (matrix* (row-matrix [1 2 3 4])
                            (col-matrix [1 2 3 4]))
                   (matrix [[30]]))
-    
+
     (check-equal? (matrix* (col-matrix [1 2 3 4])
                            (row-matrix [1 2 3 4]))
                   (matrix [[1  2  3  4]
                            [2  4  6  8]
                            [3  6  9 12]
                            [4  8 12 16]]))
-    
+
     (check-equal? (matrix* (matrix [[3]]) (matrix [[7]]))
                   (matrix [[21]]))
-    
+
     ;; Left/right identity
     (let ([m  (random-matrix 2 2)])
       (check-equal? (matrix* (identity-matrix 2) m)
                     m)
       (check-equal? (matrix* m (identity-matrix 2))
                     m))
-    
+
     ;; Shape
     (let ([m0  (random-matrix 4 5)]
           [m1  (random-matrix 5 2)]
@@ -399,9 +399,9 @@
       (check-equal? (let-values ([(m n)  (matrix-shape (matrix* m0 m1 m2))])
                       (list m n))
                     (list 4 10)))
-    
+
     (check-exn exn:fail? (λ () (matrix* (random-matrix 1 2) (random-matrix 3 2))))
-    
+
     ;; Associativity
     (let ([m0  (random-matrix 4 5)]
           [m1  (random-matrix 5 2)]
@@ -587,6 +587,23 @@
 (for: ([a  (in-list nonmatrices)])
   (check-exn exn:fail:contract? (λ () (matrix-stack (list a))))
   (check-exn exn:fail:contract? (λ () (matrix-stack (list (matrix [[1]]) a)))))
+
+;; ===================================================================================================
+;; Setters
+
+(let ([sys (matrix [[1 2 3]
+                    [4 5 6]
+                    [7 8 9]])]
+      [new-col (col-matrix [-1 -2 -3])])
+  (check-equal? (matrix-set-column sys new-col 0)
+                (array #[#[-1 2 3] #[-2 5 6] #[-3 8 9]])))
+
+(let ([sys (matrix [[1 2 3]
+                    [4 5 6]
+                    [7 8 9]])]
+      [new-row (row-matrix [-1 -2 -3])])
+  (check-equal? (matrix-set-row sys new-row 0)
+                (array #[#[-1 -2 -3] #[4 5 6] #[7 8 9]])))
 
 ;; ===================================================================================================
 ;; Inner product space
@@ -1027,7 +1044,7 @@
 ;; Tests not yet converted to rackunit
 
 (begin
-  
+
   (begin
     "matrix-operations.rkt"
     (list 'column-project
@@ -1037,12 +1054,12 @@
     (list 'projection-on-orthogonal-basis
           (equal? (projection-on-orthogonal-basis #(3 -2 2) (list #(-1 0 2) #( 2 5 1)))
                   (col-matrix [-1/3 -1/3 1/3]))
-          (equal? (projection-on-orthogonal-basis 
+          (equal? (projection-on-orthogonal-basis
                    (col-matrix [3 -2 2]) (list #(-1 0 2) (col-matrix [2 5 1])))
                   (col-matrix [-1/3 -1/3 1/3])))
     (list 'projection-on-orthonormal-basis
-          (equal? (projection-on-orthonormal-basis 
-                   #(1 2 3 4) 
+          (equal? (projection-on-orthonormal-basis
+                   #(1 2 3 4)
                    (list (matrix-scale (col-matrix [ 1  1  1  1]) 1/2)
                          (matrix-scale (col-matrix [-1  1 -1  1]) 1/2)
                          (matrix-scale (col-matrix [ 1 -1 -1  1]) 1/2)))
@@ -1065,7 +1082,7 @@
       (define 4*e2 (matrix-scale e2 4))
       (begin
         (list 'matrix-2d-rotation
-              (<= (matrix-norm (matrix- (matrix* (matrix-2d-rotation (/ pi 2)) e1) e2 )) epsilon.0) 
+              (<= (matrix-norm (matrix- (matrix* (matrix-2d-rotation (/ pi 2)) e1) e2 )) epsilon.0)
               (<= (matrix-norm (matrix- (matrix* (matrix-2d-rotation (/ pi 2)) e2) -e1)) epsilon.0))
         (list
          'matrix-2d-scaling

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -595,14 +595,14 @@
                     [4 5 6]
                     [7 8 9]])]
       [new-col (col-matrix [-1 -2 -3])])
-  (check-equal? (matrix-set-column sys new-col 0)
+  (check-equal? (matrix-set-col sys 0 new-col)
                 (array #[#[-1 2 3] #[-2 5 6] #[-3 8 9]])))
 
 (let ([sys (matrix [[1 2 3]
                     [4 5 6]
                     [7 8 9]])]
       [new-row (row-matrix [-1 -2 -3])])
-  (check-equal? (matrix-set-row sys new-row 0)
+  (check-equal? (matrix-set-row sys 0 new-row)
                 (array #[#[-1 -2 -3] #[4 5 6] #[7 8 9]])))
 
 ;; ===================================================================================================


### PR DESCRIPTION
Hi folks,

This change adds 2 new functions to `racket/math/matrix`

`matrix-set-col` takes a matrix `M`, a col-matrix `new-col` (nx1 matrix), and an `idx` and sets the column at index `idx` to `col-matrix`

`matrix-set-row` does the same with a row-matrix instead of a col-matrix

This doesn't mutate the underlying matrix, so I have omitted the `!`

This is my first time contributing a function, so please let me know if I am missing anything! I have added the functions, tests, and documentation but I'm not sure if I've missed anything

Thanks!