### PR TITLE
simplify prime-strong-pseudo?

### DIFF
--- a/math-lib/math/private/number-theory/number-theory.rkt
+++ b/math-lib/math/private/number-theory/number-theory.rkt
@@ -185,9 +185,7 @@
 
 (: prime-strong-pseudo? : Natural -> Boolean)
 (define (prime-strong-pseudo? n)
-  (let ([explanation (prime-strong-pseudo/explanation n)])
-    (or (eq? explanation 'very-probably-prime)
-        (eq? explanation #t))))
+  (eq? (prime-strong-pseudo/explanation n) 'very-probably-prime))
 
 
 (: prime? : Integer -> Boolean)


### PR DESCRIPTION
The return type of `prime-strong-pseudo/explanation` is `Strong-Test-Result`, which is either `'very-probably-prime`, `'composite`, or a natural number. As a result, it can never be `#t`, and the expression `(eq? explanation #t)` will always be false. Therefore, the whole expression is simplified to only the test against `'very-probably-prime`.