### PR TITLE
flbracketed-root: avoid underflow near root

### DIFF
--- a/math-lib/math/private/flonum/flonum-brent-dekker.rkt
+++ b/math-lib/math/private/flonum/flonum-brent-dekker.rkt
@@ -88,7 +88,7 @@
         [(= fb 0.0)  b]
         [(or (flnan? a) (flnan? fa) (flnan? b) (flnan? fb))  +nan.0]
         ;; Check signs
-        [((* fa fb) . >= . 0.0)
+        [(if (< fa 0.) (< fb 0.) (< 0. fb))
          (debugf "(f ~v) = ~v and (f ~v) = ~v do not bracket a root~n" a fa b fb)
          +nan.0]
         [else

--- a/math-test/math/tests/flonum-tests.rkt
+++ b/math-test/math/tests/flonum-tests.rkt
@@ -197,3 +197,7 @@ fl2<=
 (check-equal? (parameterize ([print-fp-test-progress? #f])
                 (test-floating-point 10000))
               empty)
+
+;; ===================================================================================================
+;; Bracketed root
+(check-equal? (flbracketed-root values -1e-200 1e-199) 0.)


### PR DESCRIPTION
the current test for deciding if the starting values bracket the root could result in underflow:
```
(require math/flonum)
(flbracketed-root values -1e-200 1e-199)
;; +nan.0
```

this corrects detection of bracketed values