### PR TITLE
Acos in matrix angle

### DIFF
--- a/math-lib/math/private/matrix/matrix-basic.rkt
+++ b/math-lib/math/private/matrix/matrix-basic.rkt
@@ -312,9 +312,7 @@
 (define (matrix-cos-angle M N)
   (/ (matrix-dot M N) (* (matrix-2norm M) (matrix-2norm N))))
 
-(: matrix-angle (case-> ((Matrix Flonum) (Matrix Flonum) -> Flonum)
-                        ((Matrix Real) (Matrix Real) -> Real)
-                        ((Matrix Float-Complex) (Matrix Float-Complex) -> Float-Complex)
+(: matrix-angle (case-> ((Matrix Float-Complex) (Matrix Float-Complex) -> Float-Complex)
                         ((Matrix Number) (Matrix Number) -> Number)))
 (define (matrix-angle M N)
   (acos (matrix-cos-angle M N)))

--- a/math-lib/math/private/matrix/matrix-operator-norm.rkt
+++ b/math-lib/math/private/matrix/matrix-operator-norm.rkt
@@ -79,9 +79,7 @@ See "How to Measure Errors" in the LAPACK manual for more details:
   ;(matrix-min-singular-value (matrix* (matrix-hermitian M) R))
   (error 'unimplemented))
 
-(: matrix-basis-angle (case-> ((Matrix Flonum) (Matrix Flonum) -> Flonum)
-                              ((Matrix Real) (Matrix Real) -> Real)
-                              ((Matrix Float-Complex) (Matrix Float-Complex) -> Float-Complex)
+(: matrix-basis-angle (case-> ((Matrix Float-Complex) (Matrix Float-Complex) -> Float-Complex)
                               ((Matrix Number) (Matrix Number) -> Number)))
 ;; Returns the angle between the two subspaces spanned by the two given sets of column vectors
 (define (matrix-basis-angle M R)

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -661,7 +661,39 @@
   (check-exn exn:fail:contract? (λ () (matrix-dot a (matrix [[1]]))))
   (check-exn exn:fail:contract? (λ () (matrix-dot (matrix [[1]]) a))))
 
-;; TODO: matrix-angle
+;; matrix-angle
+;; guarantee that matrix-cos-angle on real is in [-1 .. 1] except for zero?
+(for: ([i (in-range 10)])
+      (define n (+ 1 (random 3)))
+      (define m (+ 1 (random 4)))
+      (define A (random-matrix n m))
+      (define B (random-matrix n m))
+      (define ca (matrix-cos-angle A B))
+      (check-true (or (and (rational? ca) (<= ca 1.))
+                      (matrix-zero? A) (matrix-zero? B))))
+(let ([A (matrix [[-1.65e+145 -9.55e+152]])]
+      [B (matrix [[-2.05e-130 -1.88e-122]])])
+  (check-true (<= (abs (matrix-cos-angle A B)) 1.)))
+;; check matrix-cos-angle doesn't overflow easily
+(let ([A (matrix [[-1.20e-21+8.16e+173i -3.18e+280-4.15e+275i]])]
+      [B (matrix [[-2.51e-270-4.38e-68i -1.65e+232+3.06e+227i]])])
+  (define ca (matrix-cos-angle A B))
+  ;; 0.9999999995008538+3.159576900273938e-05i
+  (check-true (<= (magnitude ca) (flnext 1.))))
+(let ([A (matrix-scale (matrix [[1 1]]) 1e270+3.i)]
+      [B (matrix-scale (matrix [[9 0]]) 1e270+3.i)])
+  (define ca (matrix-cos-angle A B))
+  ;; 0.9999999995008538+3.159576900273938e-05i
+  (check-true (<= (magnitude (- ca (make-rectangular (sqrt 1/2) 0.))) epsilon.0)))
+;; check matrix-cos-angle treats axes with inf as principal axes
+(check-equal? (matrix-cos-angle (matrix [[1 5] [2 9]])
+                                (matrix [[2 8] [3 -inf.0]]))
+              (matrix-cos-angle (matrix [[1 5] [2 9]])
+                                (matrix [[0. 0.] [0. -1.0]])))
+(check-equal? (matrix-cos-angle (matrix [[2 9]])
+                                (matrix [[3 -8+inf.0i]]))
+              (matrix-cos-angle (matrix [[2 9]])
+                                (matrix [[0. -0+1.0i]])))
 
 ;; TODO: matrix-normalize
 


### PR DESCRIPTION
possible alternative for fixing acos/asin (#99 )

* restrict type for `matrix-basis-angle` based on corrected type of acos/asin (@samth )  (which errors since it depends on `matrix-basis-cos-angle` which is not implemented) 
* improve `matrix-cos-angle` so
  * Real values are between -1 and 1
  * Complex values have a magnitude at most `(flnext 1.)`
  * prevent early under/overflow
  * rescale matrix with inf values to a matrix of zero and ones (so it works similar to angle)
* improve `matrix-angle` so original type can be preserved
  * For real values use flacos
  * ok since Real values are now guaranteed to be within -1 to 1