### PR TITLE
Extend `make-array`, `build-array`, and `build-simple-array` to support empty arrays

### DIFF
--- a/math-doc/math/scribblings/math-array.scrbl
+++ b/math-doc/math/scribblings/math-array.scrbl
@@ -7,7 +7,7 @@
                      math plot
                      (only-in typed/racket/base
                               ann inst : λ: define: make-predicate ->
-                              Flonum Real Boolean Any Integer Index Natural Exact-Positive-Integer
+                              Flonum Real Boolean Nothing Any Integer Index Natural Exact-Positive-Integer
                               Nonnegative-Real Sequenceof Fixnum Values Number Float-Complex
                               All U List Vector Listof Vectorof Struct FlVector
                               Symbol Output-Port))
@@ -719,20 +719,41 @@ the array's elements:
 Another way to create mutable arrays from literal data is to use @racket[vector->array].
 }
 
-@defproc[(make-array [ds In-Indexes] [value A]) (Array A)]{
-Returns an array with @tech{shape} @racket[ds], with every element's value as @racket[value].
-Analogous to @racket[make-vector].
-@examples[#:eval typed-eval
-                 (make-array #() 5)
-                 (make-array #(1 2) 'sym)
-                 (make-array #(4 0 2) "Invisible")]
+@defproc*[([(make-array [ds In-Indexes]) (Array Nothing)]
+           [(make-array [ds In-Indexes] [value A]) (Array A)])]{
+Returns an array with @tech{shape} @racket[ds].
+
+@itemlist[
+  @item{If @racket[value] is not provided, @racket[ds] must contain at least one @racket[0].
+        @examples[#:eval typed-eval
+                  (make-array #())
+                  (make-array #(1 2))
+                  (make-array #(4 0 2))]}
+  @item{If @racket[value] is provided, the array is populated with every element
+        set to @racket[value]. Analogous to @racket[make-vector].
+        @examples[#:eval typed-eval
+                  (make-array #() 5)
+                  (make-array #(1 2) 'sym)
+                  (make-array #(4 0 2) "Invisible")]}
+]
+
 The arrays returned by @racket[make-array] do not allocate storage for their elements and
 are @tech{strict}.
 }
 
-@defproc[(build-array [ds In-Indexes] [proc (Indexes -> A)]) (Array A)]{
-Returns an array with @tech{shape} @racket[ds] and @tech{procedure} @racket[proc].
-Analogous to @racket[build-vector].
+@defproc*[([(build-array [ds In-Indexes]) (Array Nothing)]
+           [(build-array [ds In-Indexes] [proc (Indexes -> A)]) (Array A)])]{
+Returns an array with @tech{shape} @racket[ds].
+
+@itemlist[
+  @item{If @racket[proc] is not provided, @racket[ds] must contain at least one @racket[0].
+        @examples[#:eval typed-eval
+                  (build-array #())
+                  (build-array #(1 2))
+                  (build-array #(4 0 2))]}
+  @item{If @racket[proc] is provided, it is the @tech{procedure} of the array.
+        Analogous to @racket[build-vector].}
+]
 }
 
 @defproc[(array->mutable-array [arr (Array A)]) (Mutable-Array A)]{
@@ -1932,7 +1953,8 @@ Apply one of these to return values from library functions to ensure that users 
 by default. See @secref{array:nonstrict} for details.
 }
 
-@defproc[(build-simple-array [ds In-Indexes] [proc (Indexes -> A)]) (Array A)]{
+@defproc*[([(build-simple-array [ds In-Indexes]) (Array Nothing)]
+           [(build-simple-array [ds In-Indexes] [proc (Indexes -> A)]) (Array A)])]{
 Like @racket[build-array], but returns an array without storage that is nevertheless considered to be
 strict, regardless of the value of @racket[array-strictness].
 Such arrays will @italic{not} cache their elements when @racket[array-strict!] or

--- a/math-lib/math/private/array/array-constructors.rkt
+++ b/math-lib/math/private/array/array-constructors.rkt
@@ -6,7 +6,8 @@
  (begin (require "array-struct.rkt")
         (require "utils.rkt"))
  "typed-array-constructors.rkt"
- [make-array        (All (A) ((Vectorof Integer) A -> (Array A)))]
+ [make-array        (All (A) (case-> ((Vectorof Integer) -> (Array Nothing))
+                                     ((Vectorof Integer) A -> (Array A))))]
  [axis-index-array  ((Vectorof Integer) Integer -> (Array Index))]
  [index-array       ((Vectorof Integer) -> (Array Index))]
  [indexes-array     ((Vectorof Integer) -> (Array Indexes))])

--- a/math-lib/math/private/array/array-struct.rkt
+++ b/math-lib/math/private/array/array-struct.rkt
@@ -12,8 +12,10 @@
 (require/untyped-contract
  (begin (require (only-in "typed-array-struct.rkt" Array)))
  "typed-array-struct.rkt"
- [build-array  (All (A) ((Vectorof Integer) ((Vectorof Index) -> A) -> (Array A)))]
- [build-simple-array  (All (A) ((Vectorof Integer) ((Vectorof Index) -> A) -> (Array A)))]
+ [build-array  (All (A) (case-> ((Vectorof Integer) -> (Array Nothing))
+                                ((Vectorof Integer) ((Vectorof Index) -> A) -> (Array A))))]
+ [build-simple-array  (All (A) (case-> ((Vectorof Integer) -> (Array Nothing))
+                                       ((Vectorof Integer) ((Vectorof Index) -> A) -> (Array A))))]
  [list->array (All (A) (case-> ((Listof A) -> (Array A))
                                ((Vectorof Integer) (Listof A) -> (Array A))))])
 

--- a/math-lib/math/private/array/typed-array-constructors.rkt
+++ b/math-lib/math/private/array/typed-array-constructors.rkt
@@ -6,11 +6,20 @@
 
 (provide (all-defined-out))
 
-(: make-array (All (A) (In-Indexes A -> (Array A))))
-(define (make-array ds v)
-  (let ([ds  (check-array-shape
-              ds (λ () (raise-argument-error 'make-array "(Vectorof Index)" 0 ds v)))])
-    (unsafe-build-simple-array ds (λ (js) v))))
+(: make-array (All (A) (case-> (In-Indexes -> (Array Nothing))
+                               (In-Indexes A -> (Array A)))))
+(define make-array
+  (case-lambda
+    [(ds)
+     (unless (for/or : Boolean ([d (in-vector ds)]) (eqv? 0 d))
+       (raise-argument-error 'make-array "array shape contains at least one 0" 0 ds))
+     (let ([ds  (check-array-shape
+                 ds (λ () (raise-argument-error 'make-array "(Vectorof Index)" 0 ds)))])
+       (unsafe-build-simple-array ds (λ (js) (error "this procedure should never be called"))))]
+    [(ds v)
+     (let ([ds  (check-array-shape
+                 ds (λ () (raise-argument-error 'make-array "(Vectorof Index)" 0 ds v)))])
+       (unsafe-build-simple-array ds (λ (js) v)))]))
 
 (: axis-index-array (In-Indexes Integer -> (Array Index)))
 (define (axis-index-array ds k)

--- a/math-test/math/tests/array-tests.rkt
+++ b/math-test/math/tests/array-tests.rkt
@@ -245,6 +245,16 @@
 ;; ---------------------------------------------------------------------------------------------------
 ;; Other constructors
 
+(check-equal? (make-array #(4 0 2))
+              (build-array #(4 0 2)))
+
+(check-equal? (build-array #(4 0 2))
+              (build-simple-array #(4 0 2)))
+
+(check-pred zero? (array-size (make-array #(4 0 2))))
+(check-pred zero? (array-size (build-array #(4 0 2))))
+(check-pred zero? (array-size (build-simple-array #(4 0 2))))
+
 (check-equal? (make-array #(3 3) 0)
               (build-array #(3 3) (λ (js) 0)))
 


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers.

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

This PR aims to support the creation of empty arrays (arrays of type `(Array Nothing)`):

```racket
> (make-array #())
make-array: contract violation
  expected: array shape contains at least one 0
  given: '#()
> (make-array #(1 2))
make-array: contract violation
  expected: array shape contains at least one 0
  given: '#(1 2)
> (make-array #(4 0 2))
- : #(struct:Array
      (Indexes Index (Boxof Boolean) (-> Void) (-> Indexes Nothing))
      #<syntax:/usr/share/racket/pkgs/math-lib/math/private/array/typed-array-struct.rkt:56:13 prop:equal+hash>
      #<syntax:/usr/share/racket/pkgs/math-lib/math/private/array/typed-array-struct.rkt:55:13 prop:custom-write>
      #<syntax:/usr/share/racket/pkgs/math-lib/math/private/array/typed-array-struct.rkt:54:13 prop:custom-print-quotable>)
(array #[#[] #[] #[] #[]])
```