### PR TITLE
Relax input restrictions for `block-diagonal-matrix` to support empty arrays

### DIFF
--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -3,7 +3,6 @@
 @(require scribble/eval
           racket/sandbox
           (for-label racket/base
-                     racket/function
                      racket/match
                      racket/vector
                      racket/string
@@ -20,8 +19,7 @@
 
 @(define untyped-eval (make-untyped-math-eval))
 @interaction-eval[#:eval untyped-eval
-                         (require racket/function
-                                  racket/match
+                         (require racket/match
                                   racket/vector
                                   racket/string
                                   racket/sequence
@@ -29,8 +27,7 @@
 
 @(define typed-eval (make-math-eval))
 @interaction-eval[#:eval typed-eval
-                         (require racket/function
-                                  racket/match
+                         (require racket/match
                                   racket/vector
                                   racket/string
                                   racket/sequence
@@ -273,24 +270,24 @@ Returns an array with two-dimensional arrays @racket[Xs] along the diagonal and
 Empty two-dimensional arrays are valid inputs. They contribute to the resulting
 array's @tech{shape}.
 @examples[#:eval typed-eval
-                 (block-diagonal-matrix (list (build-simple-array #(2 0) (const 1))
+                 (block-diagonal-matrix (list (make-array #(2 0) 1)
                                               (matrix [[6 7] [8 9]])))
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
-                                              (build-simple-array #(2 0) (const 1))))
-                 (block-diagonal-matrix (list (build-simple-array #(0 2) (const 1))
+                                              (make-array #(2 0) 1)))
+                 (block-diagonal-matrix (list (make-array #(0 2) 1)
                                               (matrix [[6 7] [8 9]])))
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
-                                              (build-simple-array #(0 2) (const 1))))
+                                              (make-array #(0 2) 1)))
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
-                                              (build-simple-array #(2 0) (const 1))
+                                              (make-array #(2 0) 1)
                                               (diagonal-matrix '(7 5 7))
-                                              (build-simple-array #(0 2) (const 1))
+                                              (make-array #(0 2) 1)
                                               (col-matrix [1 2 3])
                                               (row-matrix [4 5 6])))
-                 (block-diagonal-matrix (list (build-simple-array #(2 0) (const 1))
-                                              (build-simple-array #(0 3) (const 1))))
-                 (block-diagonal-matrix (list (build-simple-array #(0 3) (const 1))
-                                              (build-simple-array #(2 0) (const 1))))]
+                 (block-diagonal-matrix (list (make-array #(2 0) 1)
+                                              (make-array #(0 3) 1)))
+                 (block-diagonal-matrix (list (make-array #(0 3) 1)
+                                              (make-array #(2 0) 1)))]
 
 If @racket[Xs] is @racket[null], the result is an empty array with @tech{shape}
 @racket[#(0 0)].

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -250,13 +250,22 @@ The length of @racket[xs] must be positive.
 
 @define[block-diagonal-url]{http://en.wikipedia.org/wiki/Block_matrix#Block_diagonal_matrices}
 
-@defproc[(block-diagonal-matrix [Xs (Listof (Matrix A))] [zero A 0]) (Matrix A)]{
+@defproc[(block-diagonal-matrix [Xs (Listof (Array A))] [zero A 0]) (Array A)]{
 @margin-note*{@hyperlink[block-diagonal-url]{Wikipedia: Block-diagonal matrices}}
-Returns a matrix with matrices @racket[Xs] along the diagonal and @racket[zero] everywhere else.
-The length of @racket[Xs] must be positive.
+Returns an array with two-dimensional arrays @racket[Xs] along the diagonal and
+@racket[zero] everywhere else.
 @examples[#:eval typed-eval
+                 (block-diagonal-matrix '())
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
                                               (diagonal-matrix '(7 5 7))
+                                              (col-matrix [1 2 3])
+                                              (row-matrix [4 5 6])))
+                 (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
+                                              (build-simple-array #(2 0) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))
+                                              (diagonal-matrix '(7 5 7))
+                                              (build-simple-array #(0 2) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))
                                               (col-matrix [1 2 3])
                                               (row-matrix [4 5 6])))
                  (block-diagonal-matrix (list (make-matrix 2 2 2.0+3.0i)

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -255,11 +255,17 @@ The length of @racket[xs] must be positive.
 Returns an array with two-dimensional arrays @racket[Xs] along the diagonal and
 @racket[zero] everywhere else.
 @examples[#:eval typed-eval
-                 (block-diagonal-matrix '())
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
                                               (diagonal-matrix '(7 5 7))
                                               (col-matrix [1 2 3])
                                               (row-matrix [4 5 6])))
+                 (block-diagonal-matrix (list (make-matrix 2 2 2.0+3.0i)
+                                              (make-matrix 2 2 5.0+7.0i))
+                                        0.0+0.0i)]
+
+Empty two-dimensional arrays are valid inputs. They contribute to the resulting
+array's @tech{shape}.
+@examples[#:eval typed-eval
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
                                               (build-simple-array #(2 0) (λ: ([js : Indexes])
                                                                            (error "this procedure should never be called")))
@@ -268,9 +274,19 @@ Returns an array with two-dimensional arrays @racket[Xs] along the diagonal and
                                                                            (error "this procedure should never be called")))
                                               (col-matrix [1 2 3])
                                               (row-matrix [4 5 6])))
-                 (block-diagonal-matrix (list (make-matrix 2 2 2.0+3.0i)
-                                              (make-matrix 2 2 5.0+7.0i))
-                                        0.0+0.0i)]
+                 (block-diagonal-matrix (list (build-simple-array #(2 0) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))
+                                              (build-simple-array #(0 3) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))))
+                 (block-diagonal-matrix (list (build-simple-array #(0 3) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))
+                                              (build-simple-array #(2 0) (λ: ([js : Indexes])
+                                                                           (error "this procedure should never be called")))))]
+
+If @racket[Xs] is @racket[null], the result is an empty array with @tech{shape}
+@racket[#(0 0)].
+@examples[#:eval typed-eval
+                 (block-diagonal-matrix '())]
 }
 
 @define[vandermonde-url]{http://en.wikipedia.org/wiki/Vandermonde_matrix}

--- a/math-doc/math/scribblings/math-matrix.scrbl
+++ b/math-doc/math/scribblings/math-matrix.scrbl
@@ -2,7 +2,12 @@
 
 @(require scribble/eval
           racket/sandbox
-          (for-label racket/base racket/vector racket/match racket/unsafe/ops racket/string
+          (for-label racket/base
+                     racket/function
+                     racket/match
+                     racket/vector
+                     racket/string
+                     racket/unsafe/ops
                      (except-in racket/list permutations) ; FIXME
                      math plot
                      (only-in typed/racket/base
@@ -15,7 +20,8 @@
 
 @(define untyped-eval (make-untyped-math-eval))
 @interaction-eval[#:eval untyped-eval
-                         (require racket/match
+                         (require racket/function
+                                  racket/match
                                   racket/vector
                                   racket/string
                                   racket/sequence
@@ -23,7 +29,8 @@
 
 @(define typed-eval (make-math-eval))
 @interaction-eval[#:eval typed-eval
-                         (require racket/match
+                         (require racket/function
+                                  racket/match
                                   racket/vector
                                   racket/string
                                   racket/sequence
@@ -266,22 +273,24 @@ Returns an array with two-dimensional arrays @racket[Xs] along the diagonal and
 Empty two-dimensional arrays are valid inputs. They contribute to the resulting
 array's @tech{shape}.
 @examples[#:eval typed-eval
+                 (block-diagonal-matrix (list (build-simple-array #(2 0) (const 1))
+                                              (matrix [[6 7] [8 9]])))
                  (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
-                                              (build-simple-array #(2 0) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))
+                                              (build-simple-array #(2 0) (const 1))))
+                 (block-diagonal-matrix (list (build-simple-array #(0 2) (const 1))
+                                              (matrix [[6 7] [8 9]])))
+                 (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
+                                              (build-simple-array #(0 2) (const 1))))
+                 (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
+                                              (build-simple-array #(2 0) (const 1))
                                               (diagonal-matrix '(7 5 7))
-                                              (build-simple-array #(0 2) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))
+                                              (build-simple-array #(0 2) (const 1))
                                               (col-matrix [1 2 3])
                                               (row-matrix [4 5 6])))
-                 (block-diagonal-matrix (list (build-simple-array #(2 0) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))
-                                              (build-simple-array #(0 3) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))))
-                 (block-diagonal-matrix (list (build-simple-array #(0 3) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))
-                                              (build-simple-array #(2 0) (λ: ([js : Indexes])
-                                                                           (error "this procedure should never be called")))))]
+                 (block-diagonal-matrix (list (build-simple-array #(2 0) (const 1))
+                                              (build-simple-array #(0 3) (const 1))))
+                 (block-diagonal-matrix (list (build-simple-array #(0 3) (const 1))
+                                              (build-simple-array #(2 0) (const 1))))]
 
 If @racket[Xs] is @racket[null], the result is an empty array with @tech{shape}
 @racket[#(0 0)].

--- a/math-lib/math/matrix.rkt
+++ b/math-lib/math/matrix.rkt
@@ -16,6 +16,7 @@
                     matrix-inverse
                     matrix-solve)
          (except-in "private/matrix/matrix-constructors.rkt"
+                    block-diagonal-matrix
                     vandermonde-matrix)
          (except-in "private/matrix/matrix-basic.rkt"
                     matrix-1norm
@@ -85,6 +86,9 @@
 (require/untyped-contract
  (begin (require "private/matrix/matrix-types.rkt"))
  "private/matrix/matrix-constructors.rkt"
+ [block-diagonal-matrix
+  (All (A) (case-> ((Listof (Matrix A)) -> (Matrix (U A 0)))
+                   ((Listof (Matrix A)) A -> (Matrix A))))]
  [vandermonde-matrix  ((Listof Number) Integer -> (Matrix Number))])
 
 (require/untyped-contract
@@ -188,6 +192,7 @@
          matrix-inverse
          matrix-solve
          ;; matrix-constructors.rkt
+         block-diagonal-matrix
          vandermonde-matrix
          ;; matrix-basic.rkt
          matrix-1norm

--- a/math-lib/math/private/matrix/matrix-constructors.rkt
+++ b/math-lib/math/private/matrix/matrix-constructors.rkt
@@ -85,16 +85,19 @@
 ;; ===================================================================================================
 ;; Block diagonal matrices
 
-(: block-diagonal-matrix/zero* (All (A) (Vectorof (Matrix A)) A -> (Matrix A)))
+(: block-diagonal-matrix/zero* (All (A) (Vectorof (Array A)) A -> (Array A)))
 (define (block-diagonal-matrix/zero* as zero)
   (define num (vector-length as))
   (define-values (ms ns)
-    (let-values ([(ms ns)  (for/fold: ([ms : (Listof Index)  empty]
-                                       [ns : (Listof Index)  empty]
-                                       ) ([a  (in-vector as)])
-                             (define-values (m n) (matrix-shape a))
-                             (values (cons m ms) (cons n ns)))])
-      (values (reverse ms) (reverse ns))))
+    (for/foldr: ([ms : (Listof Index)  empty]
+                 [ns : (Listof Index)  empty]
+                 ) ([a  (in-vector as)])
+      (define ds (array-shape a))
+      (unless (= 2 (vector-length ds))
+        (raise-argument-error 'block-diagonal-matrix "two-dimensional array" a))
+      (define m (vector-ref ds 0))
+      (define n (vector-ref ds 1))
+      (values (cons m ms) (cons n ns))))
   (define res-m (assert (apply + ms) index?))
   (define res-n (assert (apply + ns) index?))
   (define vs ((inst make-vector Index) res-m 0))
@@ -136,19 +139,24 @@
             [else
              zero])))))
 
-(: block-diagonal-matrix/zero (All (A) ((Listof (Matrix A)) A -> (Matrix A))))
-(define (block-diagonal-matrix/zero as zero)
-  (let ([as  (list->vector as)])
-    (define num (vector-length as))
-    (cond [(= num 0)
-           (raise-argument-error 'block-diagonal-matrix/zero "nonempty List" as)]
-          [(= num 1)
-           (unsafe-vector-ref as 0)]
-          [else
-           (block-diagonal-matrix/zero* as zero)])))
+(: block-diagonal-matrix/zero (All (A) (case-> (Null A -> (Array Nothing))
+                                               ((Listof (Array A)) A -> (Array A)))))
+(define block-diagonal-matrix/zero
+  (let ([id  (build-simple-array #(0 0) (λ: ([js : Indexes])
+                                          (error "this procedure should never be called")))])
+    (λ (as zero)
+      (if (null? as)
+          id
+          (let ([as  (list->vector as)])
+            (define num (vector-length as))
+            (cond [(= num 1)
+                   (unsafe-vector-ref as 0)]
+                  [else
+                   (block-diagonal-matrix/zero* as zero)]))))))
 
-(: block-diagonal-matrix (All (A) (case-> ((Listof (Matrix A)) -> (Matrix (U A 0)))
-                                          ((Listof (Matrix A)) A -> (Matrix A)))))
+(: block-diagonal-matrix (All (A) (case-> (Null -> (Array Nothing))
+                                          ((Listof (Array A)) -> (Array (U A 0)))
+                                          ((Listof (Array A)) A -> (Array A)))))
 (define block-diagonal-matrix
   (case-lambda
     [(as)  (block-diagonal-matrix/zero as 0)]

--- a/math-lib/math/private/matrix/matrix-constructors.rkt
+++ b/math-lib/math/private/matrix/matrix-constructors.rkt
@@ -139,7 +139,7 @@
             [else
              zero])))))
 
-(: block-diagonal-matrix/zero (All (A) (case-> (Null A -> (Array Nothing))
+(: block-diagonal-matrix/zero (All (A) (case-> (Null Any -> (Array Nothing))
                                                ((Listof (Array A)) A -> (Array A)))))
 (define block-diagonal-matrix/zero
   (let ([id  (build-simple-array #(0 0) (λ: ([js : Indexes])

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -194,11 +194,9 @@
 (check-equal?
  (block-diagonal-matrix
   (list (matrix [[1 2] [3 4]])
-        (build-simple-array #(2 0) (λ: ([js : Indexes])
-                                     (error "this procedure should never be called")))
+        (build-simple-array #(2 0) (const 1))
         (matrix [[1 2 3] [4 5 6]])
-        (build-simple-array #(0 2) (λ: ([js : Indexes])
-                                     (error "this procedure should never be called")))
+        (build-simple-array #(0 2) (const 1))
         (matrix [[1] [3] [5]])
         (matrix [[2 4 6]])))
  (matrix [[1 2 0 0 0 0 0 0 0 0 0]

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -194,9 +194,9 @@
 (check-equal?
  (block-diagonal-matrix
   (list (matrix [[1 2] [3 4]])
-        (build-simple-array #(2 0) (const 1))
+        (make-array #(2 0) 1)
         (matrix [[1 2 3] [4 5 6]])
-        (build-simple-array #(0 2) (const 1))
+        (make-array #(0 2) 1)
         (matrix [[1] [3] [5]])
         (matrix [[2 4 6]])))
  (matrix [[1 2 0 0 0 0 0 0 0 0 0]

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -192,6 +192,27 @@
           [0 0 0 0 0 0 2 4 6]]))
 
 (check-equal?
+ (block-diagonal-matrix
+  (list (matrix [[1 2] [3 4]])
+        (build-simple-array #(2 0) (λ: ([js : Indexes])
+                                     (error "this procedure should never be called")))
+        (matrix [[1 2 3] [4 5 6]])
+        (build-simple-array #(0 2) (λ: ([js : Indexes])
+                                     (error "this procedure should never be called")))
+        (matrix [[1] [3] [5]])
+        (matrix [[2 4 6]])))
+ (matrix [[1 2 0 0 0 0 0 0 0 0 0]
+          [3 4 0 0 0 0 0 0 0 0 0]
+          [0 0 0 0 0 0 0 0 0 0 0]
+          [0 0 0 0 0 0 0 0 0 0 0]
+          [0 0 1 2 3 0 0 0 0 0 0]
+          [0 0 4 5 6 0 0 0 0 0 0]
+          [0 0 0 0 0 0 0 1 0 0 0]
+          [0 0 0 0 0 0 0 3 0 0 0]
+          [0 0 0 0 0 0 0 5 0 0 0]
+          [0 0 0 0 0 0 0 0 2 4 6]]))
+
+(check-equal?
  (block-diagonal-matrix (map (λ: ([i : Integer]) (matrix [[i]])) '(1 2 3 4)))
  (diagonal-matrix '(1 2 3 4)))
 

--- a/math-test/math/tests/matrix-tests.rkt
+++ b/math-test/math/tests/matrix-tests.rkt
@@ -214,7 +214,8 @@
  (block-diagonal-matrix (map (λ: ([i : Integer]) (matrix [[i]])) '(1 2 3 4)))
  (diagonal-matrix '(1 2 3 4)))
 
-(check-exn exn:fail:contract? (λ () (block-diagonal-matrix '())))
+(check-equal? (block-diagonal-matrix '())
+              (build-simple-array #(0 0) (λ (_) (error "This procedure should never be called"))))
 
 ;; Vandermonde matrix
 


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers.

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

This PR modifies `block-diagonal-matrix` to accept any 2D array as input, rather than enforcing strict matrix requirements.

For example:

```racket
> (block-diagonal-matrix '())
- : #(struct:Array
      (Indexes Index (Boxof Boolean) (-> Void) (-> Indexes Nothing))
      #<syntax:.../array/typed-array-struct.rkt:56:13 prop:equal+hash>
      #<syntax:.../array/typed-array-struct.rkt:55:13 prop:custom-write>
      #<syntax:.../array/typed-array-struct.rkt:54:13 prop:custom-print-quotable>)
(array #[])
> (block-diagonal-matrix (list (matrix [[6 7] [8 9]])
                               (build-simple-array #(2 0) (λ: ([js : Indexes])
                                                            (error "this procedure should never be called")))
                               (diagonal-matrix '(7 5 7))
                               (build-simple-array #(0 2) (λ: ([js : Indexes])
                                                            (error "this procedure should never be called")))
                               (col-matrix [1 2 3])
                               (row-matrix [4 5 6])))
- : #(struct:Array
      (Indexes Index (Boxof Boolean) (-> Void) (-> Indexes Byte))
      #<syntax:.../array/typed-array-struct.rkt:56:13 prop:equal+hash>
      #<syntax:.../array/typed-array-struct.rkt:55:13 prop:custom-write>
      #<syntax:.../array/typed-array-struct.rkt:54:13 prop:custom-print-quotable>)
(array
 #[#[6 7 0 0 0 0 0 0 0 0 0]
   #[8 9 0 0 0 0 0 0 0 0 0]
   #[0 0 0 0 0 0 0 0 0 0 0]
   #[0 0 0 0 0 0 0 0 0 0 0]
   #[0 0 7 0 0 0 0 0 0 0 0]
   #[0 0 0 5 0 0 0 0 0 0 0]
   #[0 0 0 0 7 0 0 0 0 0 0]
   #[0 0 0 0 0 0 0 1 0 0 0]
   #[0 0 0 0 0 0 0 2 0 0 0]
   #[0 0 0 0 0 0 0 3 0 0 0]
   #[0 0 0 0 0 0 0 0 4 5 6]])
```