### PR TITLE
Introduce `make-matrix-determinant` for field-based matrices

### DIFF
--- a/math-lib/math/matrix/algebra.rkt
+++ b/math-lib/math/matrix/algebra.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+(require typed/untyped-utils)
+
+(require "../private/matrix/matrix-types.rkt"
+         (except-in "../private/matrix/algebra/matrix-solve.rkt"
+                    make-matrix-determinant))
+
+(require/untyped-contract
+ (begin (require "../private/matrix/matrix-types.rkt"))
+ "../private/matrix/algebra/matrix-solve.rkt"
+ [make-matrix-determinant
+  ((Any * -> Any) (Any -> Any)
+   (Any * -> Any) (Any -> Any)
+   (Any Any -> Boolean)
+   (Any Any -> Boolean)
+   ->
+   ((Matrix Any) -> Any))])
+
+(provide (all-from-out "../private/matrix/matrix-types.rkt"
+                       "../private/matrix/algebra/matrix-solve.rkt")
+         ;; matrix-solve.rkt
+         make-matrix-determinant)

--- a/math-lib/math/matrix/base.rkt
+++ b/math-lib/math/matrix/base.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(require "../private/matrix/matrix-types.rkt")
+
+(provide (all-from-out "../private/matrix/matrix-types.rkt"))

--- a/math-lib/math/private/matrix/algebra/matrix-solve.rkt
+++ b/math-lib/math/private/matrix/algebra/matrix-solve.rkt
@@ -1,0 +1,81 @@
+#lang typed/racket/base
+
+(require racket/fixnum
+         racket/match
+         "utils.rkt"
+         "../matrix-types.rkt"
+         "../matrix-conversion.rkt"
+         "../matrix-basic.rkt"
+         "../../vector/vector-mutate.rkt"
+         "../../array/mutable-array.rkt")
+
+(provide
+ make-matrix-determinant
+ make-matrix-determinant/row-reduction  ; for testing
+ )
+
+;; ===================================================================================================
+;; Determinant
+
+(: make-matrix-determinant
+   (All (A) ((A * -> A) (A -> A)
+             (A * -> A) (A -> A)
+             (A A -> Boolean)
+             (A A -> Boolean)
+             ->
+             ((Matrix A) -> A))))
+(define (make-matrix-determinant +F -F *F /F =F ~F)
+  (define 1F (*F))
+  (define matrix-determinant/row-reduction
+    (make-matrix-determinant/row-reduction +F -F *F /F =F ~F))
+
+  (: matrix-determinant ((Matrix A) -> A))
+  (define (matrix-determinant M)
+    (define m (square-matrix-size M))
+    (cond
+      [(= m 0)  1F]
+      [(= m 1)  (matrix-ref M 0 0)]
+      [(= m 2)  (match-define (vector a b c d)
+                  (mutable-array-data (array->mutable-array M)))
+                (+F (*F a d) (-F (*F b c)))]
+      [(= m 3)  (match-define (vector a b c d e f g h i)
+                  (mutable-array-data (array->mutable-array M)))
+                (+F (*F     a  (+F (*F e i) (-F (*F f h))))
+                    (*F (-F b) (+F (*F d i) (-F (*F f g))))
+                    (*F     c  (+F (*F d h) (-F (*F e g)))))]
+      [else
+       (matrix-determinant/row-reduction M)]))
+  matrix-determinant)
+
+(: make-matrix-determinant/row-reduction
+   (All (A) ((A * -> A) (A -> A)
+             (A * -> A) (A -> A)
+             (A A -> Boolean)
+             (A A -> Boolean)
+             ->
+             ((Matrix A) -> A))))
+(define (make-matrix-determinant/row-reduction +F -F *F /F =F ~F)
+  (define 0F (+F))
+  (define 1F (*F))
+
+  (: elim-rows! ((Vectorof (Vectorof A)) Index Index Index A Nonnegative-Fixnum -> Void))
+  (define elim-rows! (make-elim-rows! +F -F *F /F =F))
+
+  (: matrix-determinant/row-reduction ((Matrix A) -> A))
+  (define (matrix-determinant/row-reduction M)
+    (define m (square-matrix-size M))
+    (define rows (matrix->vector* M))
+    (let loop ([i : Nonnegative-Fixnum 0] [sign 1F])
+      (cond
+        [(fx< i m)
+         (define-values (p pivot) (generic-find-partial-pivot rows m i i ~F))
+         (if (=F pivot 0F)
+             0F  ; no pivot means non-invertible matrix
+             (let ([sign  (if (= i p) sign (begin (vector-swap! rows i p)  ; swapping negates sign
+                                                  (-F sign)))])
+               (elim-rows! rows m i i pivot (fx+ i 1))  ; adding scaled rows doesn't change it
+               (loop (fx+ i 1) sign)))]
+        [else
+         (for/fold ([prod : A sign]) ([i (in-range m)])
+           (*F prod (unsafe-vector2d-ref rows i i)))])))
+  matrix-determinant/row-reduction)

--- a/math-lib/math/private/matrix/algebra/utils.rkt
+++ b/math-lib/math/private/matrix/algebra/utils.rkt
@@ -1,0 +1,49 @@
+#lang typed/racket/base
+
+(require racket/fixnum
+         "../base/utils.rkt"
+         "../../unsafe.rkt"
+         "../../vector/vector-mutate.rkt")
+
+(provide (all-from-out "../base/utils.rkt")
+         (all-defined-out))
+
+(: generic-find-partial-pivot
+   (All (A)
+        ((Vectorof (Vectorof A))
+         Index
+         Index
+         Index
+         (A A -> Boolean)
+         ->
+         (Values Index A))))
+(define (generic-find-partial-pivot rows m i j comp)
+  (for/fold ([p : Index i] [pivot (unsafe-vector2d-ref rows i j)])
+            ([l (in-range (add1 i) m)]
+             #:when (index? l))
+    (define new-pivot (unsafe-vector2d-ref rows l j))
+    (if (comp new-pivot pivot)
+        (values l new-pivot)
+        (values p pivot))))
+
+(: make-elim-rows!
+   (All (A)
+        ((A * -> A) (A -> A)
+         (A * -> A) (A -> A)
+         (A A -> Boolean)
+         ->
+         ((Vectorof (Vectorof A)) Index Index Index A Nonnegative-Fixnum -> Void))))
+(define (make-elim-rows! +F -F *F /F =F)
+  (define 0F (+F))
+  (: elim-rows! ((Vectorof (Vectorof A)) Index Index Index A Nonnegative-Fixnum -> Void))
+  (define (elim-rows! rows m i j pivot start)
+    (define row_i (unsafe-vector-ref rows i))
+    (for ([l : Nonnegative-Fixnum (in-range start m)]
+          #:unless (fx= l i)
+          #:do [(define row_l (unsafe-vector-ref rows l))
+                (define x_lj (unsafe-vector-ref row_l j))]
+          #:unless (=F x_lj 0F))
+      (vector-generic-scaled-add! row_l row_i (-F (*F x_lj (/F pivot))) j +F *F)
+      ;; Make sure the element below the pivot is zero
+      (unsafe-vector-set! row_l j 0F)))
+  elim-rows!)

--- a/math-lib/math/private/matrix/base/utils.rkt
+++ b/math-lib/math/private/matrix/base/utils.rkt
@@ -1,0 +1,86 @@
+#lang typed/racket/base
+
+(require racket/performance-hint
+         racket/string
+         "../matrix-types.rkt"
+         "../../unsafe.rkt"
+         "../../array/array-struct.rkt")
+
+(provide (all-defined-out))
+
+(: format-matrices/error ((Listof (Array Any)) -> String))
+(define (format-matrices/error as)
+  (string-join (map (λ: ([a : (Array Any)]) (format "~e" a)) as)))
+
+(: matrix-shapes (Symbol (Matrix Any) (Matrix Any) * -> (Values Index Index)))
+(define (matrix-shapes name arr . brrs)
+  (define-values (m n) (matrix-shape arr))
+  (unless (andmap (λ: ([brr : (Matrix Any)])
+                    (define-values (bm bn) (matrix-shape brr))
+                    (and (= bm m) (= bn n)))
+                  brrs)
+    (error name
+           "matrices must have the same shape; given ~a"
+           (format-matrices/error (cons arr brrs))))
+  (values m n))
+
+(: matrix-multiply-shape ((Matrix Any) (Matrix Any) -> (Values Index Index Index)))
+(define (matrix-multiply-shape arr brr)
+  (define-values (ad0 ad1) (matrix-shape arr))
+  (define-values (bd0 bd1) (matrix-shape brr))
+  (unless (= ad1 bd0)
+    (error 'matrix-multiply
+           "1st argument column size and 2nd argument row size are not equal; given ~e and ~e"
+           arr brr))
+  (values ad0 ad1 bd1))
+
+(: ensure-matrix (All (A) Symbol (Array A) -> (Array A)))
+(define (ensure-matrix name a)
+  (if (matrix? a) a (raise-argument-error name "matrix?" a)))
+
+(: ensure-row-matrix (All (A) Symbol (Array A) -> (Array A)))
+(define (ensure-row-matrix name a)
+  (if (row-matrix? a) a (raise-argument-error name "row-matrix?" a)))
+
+(: ensure-col-matrix (All (A) Symbol (Array A) -> (Array A)))
+(define (ensure-col-matrix name a)
+  (if (col-matrix? a) a (raise-argument-error name "col-matrix?" a)))
+
+
+(: sort/key (All (A B) (case-> ((Listof A) (B B -> Boolean) (A -> B) -> (Listof A))
+                               ((Listof A) (B B -> Boolean) (A -> B) Boolean -> (Listof A)))))
+;; Sometimes necessary because TR can't do inference with keyword arguments yet
+(define (sort/key lst lt? key [cache-keys? #f])
+  ((inst sort A B) lst lt? #:key key #:cache-keys? cache-keys?))
+
+(: unsafe-vector2d-ref (All (A) ((Vectorof (Vectorof A)) Integer Integer -> A)))
+(define (unsafe-vector2d-ref vss i j)
+  (unsafe-vector-ref (unsafe-vector-ref vss i) j))
+
+;; Note: this accepts +nan.0
+(define nonnegative?
+  (λ: ([x : Real]) (not (x . < . 0))))
+
+(define number-rational?
+  (λ: ([z : Number])
+    (cond [(real? z)  (rational? z)]
+          [else  (and (rational? (real-part z))
+                      (rational? (imag-part z)))])))
+
+(begin-encourage-inline
+
+  (: call/ns (All (A) ((-> (Matrix A)) -> (Matrix A))))
+  (define (call/ns thnk)
+    (array-default-strict
+     (parameterize ([array-strictness #f])
+       (thnk))))
+
+  )  ; begin-encourage-inline
+
+(: make-thread-local-box (All (A) (A -> (-> (Boxof A)))))
+(define (make-thread-local-box contents)
+  (let: ([val : (Thread-Cellof (U #f (Boxof A))) (make-thread-cell #f)])
+    (λ () (or (thread-cell-ref val)
+              (let: ([v : (Boxof A)  (box contents)])
+                (thread-cell-set! val v)
+                v)))))

--- a/math-lib/math/private/matrix/untyped-utils.rkt
+++ b/math-lib/math/private/matrix/untyped-utils.rkt
@@ -1,0 +1,49 @@
+#lang racket/base
+
+(require racket/flonum "../../base.rkt")
+
+(provide (all-defined-out))
+
+(define (eqv x)
+  (cond [(flonum? x) fl=]
+        #;[(real? x) =]
+        #;[(float-complex? x) =]
+        [else =]))
+(define (sub x)
+  (cond [(flonum? x) fl-]
+        #;[(real? x) -]
+        #;[(float-complex? x) -]
+        [else -]))
+(define (div x)
+  (cond [(flonum? x) fl/]
+        #;[(real? x) /]
+        #;[(float-complex? x) /]
+        [else /]))
+(define add
+  (let ([fc+ (λ x* (apply + 0.0 x*))])
+    (λ (x)
+      (cond [(flonum? x) fl+]
+            #;[(real? x) +]
+            [(float-complex? x) fc+]
+            [else +]))))
+(define mul
+  (let ([fc* (λ x* (apply * 1.0 x*))])
+    (λ (x)
+      (cond [(flonum? x) fl*]
+            #;[(real? x) *]
+            [(float-complex? x) fc*]
+            [else *]))))
+(define add*
+  (let ([fc+ (λ x* (apply + 0.0+0.0i x*))])
+    (λ (x)
+      (cond [(flonum? x) fl+]
+            #;[(real? x) +]
+            [(float-complex? x) fc+]
+            [else +]))))
+(define mul*
+  (let ([fc* (λ x* (apply * 1.0+0.0i x*))])
+    (λ (x)
+      (cond [(flonum? x) fl*]
+            #;[(real? x) *]
+            [(float-complex? x) fc*]
+            [else *]))))

--- a/math-lib/math/private/matrix/utils.rkt
+++ b/math-lib/math/private/matrix/utils.rkt
@@ -1,73 +1,14 @@
 #lang typed/racket/base
 
-(require racket/performance-hint
-         racket/string
+(require typed/racket/unsafe
          racket/fixnum
-         math/base
          "matrix-types.rkt"
-         "../unsafe.rkt"
-         "../array/array-struct.rkt"
-         "../vector/vector-mutate.rkt")
+         "base/utils.rkt"
+         "algebra/utils.rkt"
+         "../../base.rkt")
 
-(provide (all-defined-out))
-
-(: format-matrices/error ((Listof (Array Any)) -> String))
-(define (format-matrices/error as)
-  (string-join (map (λ: ([a : (Array Any)]) (format "~e" a)) as)))
-
-(: matrix-shapes (Symbol (Matrix Any) (Matrix Any) * -> (Values Index Index)))
-(define (matrix-shapes name arr . brrs)
-  (define-values (m n) (matrix-shape arr))
-  (unless (andmap (λ: ([brr : (Matrix Any)])
-                    (define-values (bm bn) (matrix-shape brr))
-                    (and (= bm m) (= bn n)))
-                  brrs)
-    (error name
-           "matrices must have the same shape; given ~a"
-           (format-matrices/error (cons arr brrs))))
-  (values m n))
-
-(: matrix-multiply-shape ((Matrix Any) (Matrix Any) -> (Values Index Index Index)))
-(define (matrix-multiply-shape arr brr)
-  (define-values (ad0 ad1) (matrix-shape arr))
-  (define-values (bd0 bd1) (matrix-shape brr))
-  (unless (= ad1 bd0)
-    (error 'matrix-multiply
-           "1st argument column size and 2nd argument row size are not equal; given ~e and ~e"
-           arr brr))
-  (values ad0 ad1 bd1))
-
-(: ensure-matrix (All (A) Symbol (Array A) -> (Array A)))
-(define (ensure-matrix name a)
-  (if (matrix? a) a (raise-argument-error name "matrix?" a)))
-
-(: ensure-row-matrix (All (A) Symbol (Array A) -> (Array A)))
-(define (ensure-row-matrix name a)
-  (if (row-matrix? a) a (raise-argument-error name "row-matrix?" a)))
-
-(: ensure-col-matrix (All (A) Symbol (Array A) -> (Array A)))
-(define (ensure-col-matrix name a)
-  (if (col-matrix? a) a (raise-argument-error name "col-matrix?" a)))
-
-(: sort/key (All (A B) (case-> ((Listof A) (B B -> Boolean) (A -> B) -> (Listof A))
-                               ((Listof A) (B B -> Boolean) (A -> B) Boolean -> (Listof A)))))
-;; Sometimes necessary because TR can't do inference with keyword arguments yet
-(define (sort/key lst lt? key [cache-keys? #f])
-  ((inst sort A B) lst lt? #:key key #:cache-keys? cache-keys?))
-
-(: unsafe-vector2d-ref (All (A) ((Vectorof (Vectorof A)) Index Index -> A)))
-(define (unsafe-vector2d-ref vss i j)
-  (unsafe-vector-ref (unsafe-vector-ref vss i) j))
-
-;; Note: this accepts +nan.0
-(define nonnegative?
-  (λ: ([x : Real]) (not (x . < . 0))))
-
-(define number-rational?
-  (λ: ([z : Number])
-    (cond [(real? z)  (rational? z)]
-          [else  (and (rational? (real-part z))
-                      (rational? (imag-part z)))])))
+(provide (all-from-out "base/utils.rkt")
+         (all-defined-out))
 
 (: find-partial-pivot
    (case-> ((Vectorof (Vectorof Flonum)) Index Index Index -> (Values Index Flonum))
@@ -76,16 +17,7 @@
            ((Vectorof (Vectorof Number)) Index Index Index -> (Values Index Number))))
 ;; Find the element with maximum magnitude in a column
 (define (find-partial-pivot rows m i j)
-  (define l (fx+ i 1))
-  (define pivot (unsafe-vector2d-ref rows i j))
-  (define mag-pivot (magnitude pivot))
-  (let loop ([#{l : Nonnegative-Fixnum} l] [#{p : Index} i] [pivot pivot] [mag-pivot mag-pivot])
-    (cond [(l . fx< . m)
-           (define new-pivot (unsafe-vector2d-ref rows l j))
-           (define mag-new-pivot (magnitude new-pivot))
-           (cond [(mag-new-pivot . > . mag-pivot)  (loop (fx+ l 1) l new-pivot mag-new-pivot)]
-                 [else  (loop (fx+ l 1) p pivot mag-pivot)])]
-          [else  (values p pivot)])))
+  (generic-find-partial-pivot rows m i j magnitude-compare))
 
 (: find-first-pivot
    (case-> ((Vectorof (Vectorof Flonum)) Index Index Index -> (Values Index Flonum))
@@ -107,39 +39,25 @@
 (: elim-rows!
    (case-> ((Vectorof (Vectorof Flonum)) Index Index Index Flonum Nonnegative-Fixnum -> Void)
            ((Vectorof (Vectorof Real)) Index Index Index Real Nonnegative-Fixnum -> Void)
-           ((Vectorof (Vectorof Float-Complex)) Index Index Index Float-Complex Nonnegative-Fixnum 
+           ((Vectorof (Vectorof Float-Complex)) Index Index Index Float-Complex Nonnegative-Fixnum
                                                 -> Void)
            ((Vectorof (Vectorof Number)) Index Index Index Number Nonnegative-Fixnum -> Void)))
 (define (elim-rows! rows m i j pivot start)
-  (define row_i (unsafe-vector-ref rows i))
-  (let loop ([#{l : Nonnegative-Fixnum} start])
-    (when (l . fx< . m)
-      (unless (l . fx= . i)
-        (define row_l (unsafe-vector-ref rows l))
-        (define x_lj (unsafe-vector-ref row_l j))
-        (unless (= x_lj 0)
-          (vector-scaled-add! row_l row_i (* -1 (/ x_lj pivot)) j)
-          ;; Make sure the element below the pivot is zero
-          (unsafe-vector-set! row_l j (- x_lj x_lj))))
-      (loop (fx+ l 1)))))
+  (define x00 (unsafe-vector2d-ref rows 0 0))
+  (define +F (add x00))
+  (define -F (sub x00))
+  (define *F (mul x00))
+  (define /F (div x00))
+  (define =F (eqv x00))
+  ((make-elim-rows! +F -F *F /F =F) rows m i j pivot start))
 
-(begin-encourage-inline
-  
-  (: call/ns (All (A) ((-> (Matrix A)) -> (Matrix A))))
-  (define (call/ns thnk)
-    (array-default-strict
-     (parameterize ([array-strictness #f])
-       (thnk))))
-  
-  )  ; begin-encourage-inline
 
-(: make-thread-local-box (All (A) (A -> (-> (Boxof A)))))
-(define (make-thread-local-box contents)
-  (let: ([val : (Thread-Cellof (U #f (Boxof A))) (make-thread-cell #f)])
-    (λ () (or (thread-cell-ref val)
-              (let: ([v : (Boxof A)  (box contents)])
-                (thread-cell-set! val v)
-                v)))))
+(: magnitude-compare
+   (case-> (Flonum Flonum -> Boolean)
+           (Real Real -> Boolean)
+           (Float-Complex Float-Complex -> Boolean)
+           (Number Number -> Boolean)))
+(define (magnitude-compare a b) (> (magnitude a) (magnitude b)))
 
 (: one (case-> (Flonum -> Nonnegative-Flonum)
                (Real -> (U 1 Nonnegative-Flonum))
@@ -180,3 +98,33 @@
         [(real? x)  0]
         [(float-complex? x)  0.0+0.0i]
         [else  0]))
+
+(unsafe-require/typed/provide "untyped-utils.rkt"
+  [eqv (case-> (Flonum -> (Flonum Flonum -> Boolean))
+               (Real -> (Real Real -> Boolean))
+               (Float-Complex -> (Float-Complex Float-Complex -> Boolean))
+               (Number -> (Number Number -> Boolean)))]
+  [sub (case-> (Flonum -> (Flonum * -> Flonum))
+               (Real -> (Real * -> Real))
+               (Float-Complex -> (Float-Complex * -> Float-Complex))
+               (Number -> (Number * -> Number)))]
+  [div (case-> (Flonum -> (Flonum * -> Flonum))
+               (Real -> (Real * -> Real))
+               (Float-Complex -> (Float-Complex * -> Float-Complex))
+               (Number -> (Number * -> Number)))]
+  [add (case-> (Flonum -> (Flonum * -> Flonum))
+               (Real -> (Real * -> Real))
+               (Float-Complex -> (Float-Complex * -> Float-Complex))
+               (Number -> (Number * -> Number)))]
+  [mul (case-> (Flonum -> (Flonum * -> Flonum))
+               (Real -> (Real * -> Real))
+               (Float-Complex -> (Float-Complex * -> Float-Complex))
+               (Number -> (Number * -> Number)))]
+  [add* (case-> (Flonum -> (Flonum * -> Flonum))
+                (Real -> (Real * -> Real))
+                (Float-Complex -> (Float-Complex * -> Float-Complex))
+                (Number -> (Number * -> Number)))]
+  [mul* (case-> (Flonum -> (Flonum * -> Flonum))
+                (Real -> (Real * -> Real))
+                (Float-Complex -> (Float-Complex * -> Float-Complex))
+                (Number -> (Number * -> Number)))])

--- a/math-lib/math/private/vector/vector-mutate.rkt
+++ b/math-lib/math/private/vector/vector-mutate.rkt
@@ -5,6 +5,8 @@
          math/private/unsafe)
 
 (provide vector-swap!
+         vector-generic-scale!
+         vector-generic-scaled-add!
          vector-scale!
          vector-scaled-add!
          vector-mag^2

--- a/math-test/math/tests/matrix-algebra-tests.rkt
+++ b/math-test/math/tests/matrix-algebra-tests.rkt
@@ -1,0 +1,57 @@
+#lang typed/racket/base
+
+(require math/base
+         math/array
+         (only-in math/matrix matrix build-matrix)
+         math/matrix/algebra
+         "test-utils.rkt")
+
+(: random-matrix (case-> (Integer Integer -> (Matrix Integer))
+                         (Integer Integer Integer -> (Matrix Integer))
+                         (Integer Integer Integer Integer -> (Matrix Integer))))
+;; Generates a random matrix with Natural elements < k. Useful to test properties.
+(define random-matrix
+  (case-lambda
+    [(m n)  (random-matrix m n 100)]
+    [(m n k)  (array-strict (build-matrix m n (λ (i j) (random-natural k))))]
+    [(m n k0 k1)  (array-strict (build-matrix m n (λ (i j) (random-integer k0 k1))))]))
+
+(: empty-matrix (Matrix Nothing))
+(define empty-matrix
+  (build-simple-array #(0 0) (λ (js)
+                               (error "this procedure should never be called"))))
+
+;; ===================================================================================================
+;; Determinant
+
+(: matrix-determinant ((Matrix Exact-Rational) -> Exact-Rational))
+(: matrix-determinant/row-reduction ((Matrix Exact-Rational) -> Exact-Rational))
+(define-values (matrix-determinant matrix-determinant/row-reduction)
+  (let ([+F (ann + (Exact-Rational * -> Exact-Rational))]
+        [-F (ann - (Exact-Rational -> Exact-Rational))]
+        [*F (ann * (Exact-Rational * -> Exact-Rational))]
+        [/F (ann / (Exact-Rational -> Exact-Rational))]
+        [=F (ann = (Exact-Rational Exact-Rational -> Boolean))])
+    (: ~F (Exact-Rational Exact-Rational -> Boolean))
+    (define (~F a b) (> (abs a) (abs b)))
+    (values (make-matrix-determinant +F -F *F /F =F ~F)
+            (make-matrix-determinant/row-reduction +F -F *F /F =F ~F))))
+
+(check-equal? (matrix-determinant (matrix [[3]])) 3)
+(check-equal? (matrix-determinant (matrix [[3]])) 3)
+(check-equal? (matrix-determinant (matrix [[1 2] [3 4]])) (- (* 1 4) (* 2 3)))
+(check-equal? (matrix-determinant (matrix [[1 2 3] [4  5 6] [7 8 9]])) 0)
+(check-equal? (matrix-determinant (matrix [[1 2 3] [4 -5 6] [7 8 9]])) 120)
+(check-equal? (matrix-determinant (matrix [[1 2 3 4]
+                                           [-5 6 7 8]
+                                           [9 10 -11 12]
+                                           [13 14 15 16]]))
+              5280)
+
+;; TODO Determinant of the empty matrix
+;; (check-equal? (matrix-determinant empty-matrix) 1)
+;; (check-equal? (matrix-determinant/row-reduction empty-matrix) 1)
+(for ([_  (in-range 100)])
+  (define a (random-matrix 3 3 -3 4))
+  (check-equal? (matrix-determinant/row-reduction a)
+                (matrix-determinant a)))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers.

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [ ] documentation

## Description of change
<!-- Please provide a description of the change here. -->

Adds `make-matrix-determinant` constructor that accepts field operations (`+-*/=`), and refactors existing `matrix-determinant` to use `make-matrix-determinant` internally.

Tested on `100×100` matrices with the following code:
```racket
#lang typed/racket/base

(require math/matrix)

(random-seed 1)

(: rand (-> Index Index Real))
(define (rand i j) (random 1 9))

(: n Integer)
(define n 100)

(define M (build-matrix n n rand))

(time (displayln (matrix-determinant M)))
```

The new implementation shows no significant performance difference.
