### PR TITLE
remove dependency on "r6rs-lib"

### DIFF
--- a/math-lib/info.rkt
+++ b/math-lib/info.rkt
@@ -2,8 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '(["base" #:version "6.11.0.6"]
-               "r6rs-lib"
+(define deps '(["base" #:version "8.16.0.4"]
                ["typed-racket-lib" #:version "1.14"]
                ("math-i386-macosx" #:platform "i386-macosx")
                ("math-x86_64-macosx" #:platform "x86_64-macosx")

--- a/math-lib/math/private/bigfloat/mpfr.rkt
+++ b/math-lib/math/private/bigfloat/mpfr.rkt
@@ -12,8 +12,6 @@
          racket/runtime-path
          racket/promise
          racket/serialize
-         (only-in rnrs/arithmetic/bitwise-6
-                  bitwise-first-bit-set)
          "gmp.rkt"
          "utils.rkt")
 


### PR DESCRIPTION
The `bitwise-first-bit-set` function is provided by `racket` as of v8.16.0.4.

This is part of larger effort to prune dependencies where something big gets pulled in for a small function or reference. 