### PR TITLE
Ordinary rejection sampling is faster than what `random-natural` does

### DIFF
--- a/math-lib/math/private/base/base-random.rkt
+++ b/math-lib/math/private/base/base-random.rkt
@@ -24,7 +24,6 @@
                  [else  r]))]))
 
 (define random-max 4294967087)
-(define bias-bits (* 2 block-bits))
 
 (: random-natural (Integer -> Natural))
 ;; Returns a random integer in the interval [0..n)
@@ -33,15 +32,9 @@
     [(n . <= . 0)  (raise-argument-error 'random-natural "Positive-Integer" n)]
     [(n . <= . random-max)  (random n)]
     [else
-     ;; Rejection sampling has rejection probability approaching 1/2 in the worst cases; that is,
-     ;; when n = 1+2^i for some large-ish integer i
-     ;; Adding extra bits shrinks the rejection probability to near zero (it approaches
-     ;; (* 1/2 (expt 2 (- bias-bits)))), at the cost of some bias
-     ;; The bias starts become detectable after taking (expt 2 bias-bits) samples, which is plenty
-     (define bits (+ bias-bits (integer-length (- n 1))))
-     (define m (arithmetic-shift 1 bits))
+     (define bits (integer-length (- n 1)))
      (let loop ()
-       (define r (quotient (* (+ (random-bits bits) 1) n) m))
+       (define r (random-bits bits))
        (if (r . >= . n) (loop) r))]))
 
 (: random-integer (Integer Integer -> Integer))


### PR DESCRIPTION
My Herbie project spends about 3–4% of runtime in the `random-natural` function. This lead me to look at how that function works, and in fact instead of ordinary rejection sampling, it implements a clever algorithm that biases the sampling slightly to reduce the rejection probability. But that biasing involves a bignum multiplication, and after timing it, it looks to be quite a bit slower than ordinary rejection sampling. Specifically, I ran this code for timing:

```
(module+ main
  (for ([n (in-range 10)])
    (collect-garbage)
    (time
     (for ([n (in-range 1000000)])
       (random-natural 197823238423487)))))
```


You can see that it samples a natural number below `197823238423487` and measures its runtime in nanoseconds/iter. I get 190–200 nanoseconds for ordinary rejection sampling and 400–410 nanoseconds for the clever version. I say we go back to the ordinary version.