### PR TITLE
array-append* docs: No broadcasting along axis k

### DIFF
--- a/math-doc/math/scribblings/math-array.scrbl
+++ b/math-doc/math/scribblings/math-array.scrbl
@@ -1331,7 +1331,7 @@ Almost all array transformations, including @secref{array:slicing}, are implemen
 
 @defproc[(array-append* [arrs (Listof (Array A))] [k Integer 0]) (Array A)]{
 Appends the arrays in @racket[arrs] along axis @racket[k]. If the arrays' shapes are not
-the same, they are @tech{broadcast} along all axes but the @racket[k]th first.
+the same, they are first @tech{broadcast} along all axes (except the @racket[k]th).
 @examples[#:eval typed-eval
                  (define arr (array #[#[0 1] #[2 3]]))
                  (define brr (array #[#['a 'b] #['c 'd]]))

--- a/math-doc/math/scribblings/math-array.scrbl
+++ b/math-doc/math/scribblings/math-array.scrbl
@@ -1331,7 +1331,7 @@ Almost all array transformations, including @secref{array:slicing}, are implemen
 
 @defproc[(array-append* [arrs (Listof (Array A))] [k Integer 0]) (Array A)]{
 Appends the arrays in @racket[arrs] along axis @racket[k]. If the arrays' shapes are not
-the same, they are @tech{broadcast} first.
+the same, they are @tech{broadcast} along all axes but the @racket[k]th first.
 @examples[#:eval typed-eval
                  (define arr (array #[#[0 1] #[2 3]]))
                  (define brr (array #[#['a 'b] #['c 'd]]))


### PR DESCRIPTION
This makes the documentation match the implementation and the last example.  (It may be obvious that this is what it should do, but it confused me for a while.)